### PR TITLE
Correct millisecondsPerEpoch

### DIFF
--- a/Sources/DP3TSDK/Cryptography/CryptoConstants.swift
+++ b/Sources/DP3TSDK/Cryptography/CryptoConstants.swift
@@ -17,7 +17,7 @@ enum CryptoConstants {
     static let keyLenght: Int = 16
     static let numberOfDaysToKeepData: Int = 21
     static let numberOfEpochsPerDay: Int = 24 * 12
-    static let millisecondsPerEpoch = 24 * 60 * 60 * 1000 / CryptoConstants.numberOfDaysToKeepData
+    static let millisecondsPerEpoch = Int(TimeInterval.day) * 1000 / CryptoConstants.numberOfEpochsPerDay
     static let broadcastKey: Data = "broadcast key".data(using: .utf8)!
 }
 


### PR DESCRIPTION
The `millisecondsPerEpoch` is calculated using `numberOfDaysToKeepData`, instead of `numberOfEpochsPerDay`.