### PR TITLE
Add distribution via Cocoapods

### DIFF
--- a/DP3TSDK.podspec
+++ b/DP3TSDK.podspec
@@ -1,0 +1,31 @@
+
+Pod::Spec.new do |spec|
+
+  spec.name         = "DP3TSDK"
+  spec.version      = "0.0.1"
+  spec.summary      = "Open protocol for COVID-19 proximity tracing using Bluetooth Low Energy on mobile devices"
+
+  spec.description  = <<-DESC
+  The Decentralised Privacy-Preserving Proximity Tracing (DP-3T) project is an open protocol for COVID-19 proximity tracing using Bluetooth Low Energy functionality on mobile devices that ensures personal data and computation stays entirely on an individual's phone. It was produced by a core team of over 25 scientists and academic researchers from across Europe. It has also been scrutinized and improved by the wider community.
+
+DP-3T is a free-standing effort started at EPFL and ETHZ that produced this protocol and that is implementing it in an open-sourced app and server.
+                   DESC
+
+  spec.homepage     = "https://github.com/DP-3T/documents"
+
+  spec.license      = { :type => "MPL", :file => "LICENSE" }
+
+  spec.author             = { "DP^3T" => "dp3t@groupes.epfl.ch" }
+
+  spec.platform     = :ios, "10.0"
+
+  spec.swift_versions = "5.0"
+
+  spec.source       = { :git => "https://github.com/DP-3T/dp3t-sdk-ios.git", :branch => "develop" }
+
+  spec.source_files  = "Sources", "Sources/**/*.{h,m,swift}"
+  spec.exclude_files = "Sources/DP3TSDK/Exclude"
+
+  spec.dependency "SQLite.swift", "~>0.12"
+
+end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DP3T-SDK for iOS
-[![Swift Package Manager compatible](https://img.shields.io/badge/SPM-%E2%9C%93-brightgreen.svg?style=flat)](https://github.com/apple/swift-package-manager)
+[![Swift Package Manager compatible](https://img.shields.io/badge/SPM-%E2%9C%93-brightgreen.svg?style=flat)](https://github.com/apple/swift-package-manager) ![CocoaPods compatible](https://img.shields.io/cocoapods/v/DP3TSDK)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://github.com/DP-3T/dp3t-sdk-ios/blob/master/LICENSE)
 ![build](https://github.com/DP-3T/dp3t-sdk-ios/workflows/build/badge.svg)
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ DP3T-SDK is available through [Swift Package Manager](https://swift.org/package-
   ]
 
   ```
+### Cocoapods
+
+DP3T-SDK is available through [Cocoapods](https://cocoapods.org/)
+
+1. Add the following to your `Podfile`:
+
+  ```ruby
+
+  pod 'DP3TSDK', => '0.0.1'
+
+  ```
+
+This version points to the HEAD of the `develop` branch and will always fetch the latest development status. Future releases will be made available using semantic versioning to ensure stability for depending projects.
 
 ## Using the SDK
 


### PR DESCRIPTION
Added Podspec file to represent the project in the Cocoapods spec repository. Updated README.
(Resolves #12)

**Versioning**
The Podspec currently has version 0.0.1 and always points to the HEAD of the develop branch. This should later be updated to use git tags and semantic versioning.

**Verification**
I verified the Podspec file using `pod spec lint --allow-warnings`. The flag is necessary because we don't point to a specific git tag yet, which generates a warning. I also tested importing the spec locally by creating a new project with a Podfile and adding `pod "DP3TSDK", :path => <path-to-dp3t-sdk-ios>`.

**Steps to publish**
Please check the values for the Specfile and, if all is ok, merge and publish the spec as outlined in the [Cocoapods documentation](http://guides.cocoapods.org/making/getting-setup-with-trunk.html)