### PR TITLE
Adds matching cases to its own table

### DIFF
--- a/Sources/DP3TSDK/Cryptography/CryptoConstants.swift
+++ b/Sources/DP3TSDK/Cryptography/CryptoConstants.swift
@@ -21,4 +21,5 @@ enum CryptoConstants {
     static let broadcastKey: Data = "broadcast key".data(using: .utf8)!
     static let timeZone: TimeZone = TimeZone(identifier: "UTC")!
     static let contactsThreshold: Int = 1
+    static let numberOfDaysToKeepMatchedContacts = 10
 }

--- a/Sources/DP3TSDK/DP3TSDK.swift
+++ b/Sources/DP3TSDK/DP3TSDK.swift
@@ -61,7 +61,12 @@ class DP3TSDK {
     /// keeps track of  SDK state
     private var state: TracingState {
         didSet {
-            Default.shared.infectionStatus = state.infectionStatus
+            switch state.infectionStatus {
+            case .infected:
+                Default.shared.didMarkAsInfected = true
+            default:
+                Default.shared.didMarkAsInfected = false
+            }
             Default.shared.lastSync = state.lastSync
             DispatchQueue.main.async {
                 self.delegate?.DP3TTracingStateChanged(self.state)
@@ -87,7 +92,7 @@ class DP3TSDK {
                              numberOfContacts: (try? database.contactsStorage.count()) ?? 0,
                              trackingState: .stopped,
                              lastSync: Default.shared.lastSync,
-                             infectionStatus: Default.shared.infectionStatus)
+                             infectionStatus: InfectionStatus.getInfectionState(with: database))
 
         broadcaster.permissionDelegate = self
         discoverer.permissionDelegate = self
@@ -249,7 +254,7 @@ class DP3TSDK {
     func reset() throws {
         stopTracing()
         Default.shared.lastSync = nil
-        Default.shared.infectionStatus = .healthy
+        Default.shared.didMarkAsInfected = false
         try database.emptyStorage()
         try database.destroyDatabase()
         crypto.reset()
@@ -275,7 +280,7 @@ class DP3TSDK {
 
 extension DP3TSDK: DP3TMatcherDelegate {
     func didFindMatch() {
-        state.infectionStatus = .exposed
+        state.infectionStatus = InfectionStatus.getInfectionState(with: database)
     }
 
     func handShakeAdded(_ handshake: HandshakeModel) {

--- a/Sources/DP3TSDK/DP3TTracingState.swift
+++ b/Sources/DP3TSDK/DP3TTracingState.swift
@@ -7,13 +7,26 @@
 import Foundation
 
 /// The infection status of the user
-public enum InfectionStatus: Int {
+public enum InfectionStatus {
     /// The user is healthy and had no contact with any infected person
     case healthy
+    /// The user was in contact with a person that was flagged as infected
+    case exposed(days: [MatchedContact])
     /// The user is infected and has signaled it himself
     case infected
-    /// The user was in contact with a person that was flagged as infected
-    case exposed
+
+    static func getInfectionState(with database: DP3TDatabase) -> InfectionStatus {
+        let numberOfMatchedContacts = try? database.matchedContactsStorage.count()
+        let hasMatchedContacts: Bool = (numberOfMatchedContacts ?? 0) > 0
+        if Default.shared.didMarkAsInfected {
+            return .infected
+        } else if hasMatchedContacts,
+            let matchedContacts = try? database.matchedContactsStorage.getMatchedContacts() {
+            return .exposed(days: matchedContacts)
+        } else {
+            return .healthy
+        }
+    }
 }
 
 /// The tracking state of the bluetooth and the other networking api

--- a/Sources/DP3TSDK/Database/Database.swift
+++ b/Sources/DP3TSDK/Database/Database.swift
@@ -116,6 +116,7 @@ class DP3TDatabase {
                 try loggingStorage.emptyStorage()
             #endif
             try contactsStorage.emptyStorage()
+            try matchedContactsStorage.emptyStorage()
         }
     }
 

--- a/Sources/DP3TSDK/Database/Database.swift
+++ b/Sources/DP3TSDK/Database/Database.swift
@@ -40,6 +40,13 @@ class DP3TDatabase {
         return _contactsStorage
     }
 
+    /// contacts Storage
+    private let _matchedContactsStorage: MatchedContactsStorage
+    var matchedContactsStorage: MatchedContactsStorage {
+        guard !isDestroyed else { fatalError("Database is destroyed") }
+        return _matchedContactsStorage
+    }
+
     /// knowncase Storage
     private let _knownCasesStorage: KnownCasesStorage
     var knownCasesStorage: KnownCasesStorage {
@@ -75,6 +82,7 @@ class DP3TDatabase {
         _knownCasesStorage = try KnownCasesStorage(database: connection)
         _handshakesStorage = try HandshakesStorage(database: connection)
         _contactsStorage = try ContactsStorage(database: connection, knownCasesStorage: _knownCasesStorage)
+        _matchedContactsStorage = try MatchedContactsStorage(database: connection, knownCasesStorage: _knownCasesStorage)
         _peripheralStorage = try PeripheralStorage(database: connection)
         _applicationStorage = try ApplicationStorage(database: connection)
         #if CALIBRATION

--- a/Sources/DP3TSDK/Database/Defaults.swift
+++ b/Sources/DP3TSDK/Database/Defaults.swift
@@ -32,12 +32,12 @@ class Default {
     }
 
     /// Current infection status
-    var infectionStatus: InfectionStatus {
+    var didMarkAsInfected: Bool {
         get {
-            return InfectionStatus(rawValue: store.integer(forKey: "org.dpppt.InfectionStatus")) ?? .healthy
+            return store.bool(forKey: "org.dpppt.didMarkAsInfected")
         }
         set(newValue) {
-            store.set(newValue.rawValue, forKey: "org.dpppt.InfectionStatus")
+            store.set(newValue, forKey: "org.dpppt.didMarkAsInfected")
         }
     }
 }

--- a/Sources/DP3TSDK/Database/MatchedContactsStorage.swift
+++ b/Sources/DP3TSDK/Database/MatchedContactsStorage.swift
@@ -34,8 +34,9 @@ class MatchedContactsStorage {
         try database.run(table.create(ifNotExists: true) { t in
             t.column(idColumn, primaryKey: .autoincrement)
             t.column(reportDateColumn)
-            //TODO: PP-139: setnull? does it matter?
-            t.foreignKey(associatedKnownCaseIdColumn, references: knownCasesStorage.table, knownCasesStorage.idColumn, delete: .setNull)
+            t.column(associatedKnownCaseIdColumn)
+            t.foreignKey(associatedKnownCaseIdColumn, references: knownCasesStorage.table, knownCasesStorage.idColumn, delete: .noAction)
+            t.unique([idColumn])
         })
     }
 

--- a/Sources/DP3TSDK/Database/MatchedContactsStorage.swift
+++ b/Sources/DP3TSDK/Database/MatchedContactsStorage.swift
@@ -1,0 +1,88 @@
+/*
+ * Created by Ubique Innovation AG
+ * https://www.ubique.ch
+ * Copyright (c) 2020. All rights reserved.
+ */
+
+import Foundation
+import SQLite
+
+/// Storage used to persist exposed Contacts
+class MatchedContactsStorage {
+    /// Database connection
+    private let database: Connection
+
+    /// Name of the table
+    let table = Table("matched_contacts")
+
+    /// Column definitions
+    let idColumn = Expression<Int>("id")
+    let reportDateColumn = Expression<Date>("report_date")
+    let associatedKnownCaseIdColumn = Expression<Int>("known_case_id")
+
+    /// Initializer
+    /// - Parameters:
+    ///   - database: database Connection
+    ///   - knownCasesStorage: knownCases Storage
+    init(database: Connection, knownCasesStorage: KnownCasesStorage) throws {
+        self.database = database
+        try createTable(knownCasesStorage: knownCasesStorage)
+    }
+
+    /// Create the table
+    private func createTable(knownCasesStorage: KnownCasesStorage) throws {
+        try database.run(table.create(ifNotExists: true) { t in
+            t.column(idColumn, primaryKey: .autoincrement)
+            t.column(reportDateColumn)
+            //TODO: PP-139: setnull? does it matter?
+            t.foreignKey(associatedKnownCaseIdColumn, references: knownCasesStorage.table, knownCasesStorage.idColumn, delete: .setNull)
+        })
+    }
+
+    /// count of entries
+    func count() throws -> Int {
+        try database.scalar(table.count)
+    }
+
+    /// add a matched contact
+    /// - Parameter matchedContact: the known case that matched to a contact to add
+    func add(matchedContact: MatchedContact) throws {
+        let insert = table.insert(
+            reportDateColumn <- matchedContact.reportDate,
+            associatedKnownCaseIdColumn <- matchedContact.identifier
+        )
+        try database.run(insert)
+    }
+
+    /// Helper function to retrieve Contacts from Handshakes
+    /// - Parameters:
+    ///   - day: the day for which to retreive contact
+    ///   - overlappingTimeInverval: timeinterval to add/subtract for contact retreival
+    ///   - contactThreshold: how many handshakes to have to be recognized as contact
+    /// - Throws: if a database error happens
+    /// - Returns: list of contacts
+    func getMatchedContacts() throws -> [MatchedContact] {
+        try deleteExpiredMatchedContacts()
+
+        var matchedContacts = [MatchedContact]()
+        for row in try database.prepare(table) {
+            let matchedContact = MatchedContact(identifier: row[associatedKnownCaseIdColumn],
+                                                reportDate: row[reportDateColumn])
+            matchedContacts.append(matchedContact)
+        }
+
+        return matchedContacts
+    }
+
+    /// Deletes contacts older than CryptoConstants.numberOfDaysToKeepData
+    func deleteExpiredMatchedContacts() throws {
+        let thresholdDate: Date = DayDate().dayMin.addingTimeInterval(-Double(CryptoConstants.numberOfDaysToKeepMatchedContacts) * TimeInterval.day)
+        let deleteQuery = table.filter(reportDateColumn < thresholdDate)
+        try database.run(deleteQuery.delete())
+    }
+
+    /// Delete all entries
+    func emptyStorage() throws {
+        try database.run(table.delete())
+    }
+}

--- a/Sources/DP3TSDK/Models/MatchedContact.swift
+++ b/Sources/DP3TSDK/Models/MatchedContact.swift
@@ -1,0 +1,13 @@
+/*
+* Created by Ubique Innovation AG
+* https://www.ubique.ch
+* Copyright (c) 2020. All rights reserved.
+*/
+
+import Foundation
+
+/// Mobdel used for showing matched contacts
+public struct MatchedContact {
+    let identifier: Int
+    let reportDate: Date
+}


### PR DESCRIPTION
TODO: Missing tests... (note to myself)

Implements the matching contacts table. 
Updates the table once a new matching contact is exposed
Removes entries after 10 days
Updates infection status enum with exposed having the contacts as argument now
