### PR TITLE
Add Protobuf & JWT dependencies in podspec

### DIFF
--- a/DP3TSDK.podspec
+++ b/DP3TSDK.podspec
@@ -17,7 +17,7 @@ DP-3T is a free-standing effort started at EPFL and ETHZ that produced this prot
 
   spec.author             = { "DP^3T" => "dp3t@ubique.ch" }
 
-  spec.platform     = :ios, "10.0"
+  spec.platform     = :ios, "11.0"
 
   spec.swift_versions = "5.2"
 
@@ -27,5 +27,7 @@ DP-3T is a free-standing effort started at EPFL and ETHZ that produced this prot
   spec.exclude_files = "Sources/DP3TSDK/Exclude"
 
   spec.dependency "SQLite.swift", "~>0.12"
+  spec.dependency 'SwiftProtobuf', '~> 1.6'
+  spec.dependency 'SwiftJWT', '~> 3.5'
 
 end


### PR DESCRIPTION
SDK installed from pod will not compile without the dependencies.

This is necessary for the react native bindings at https://github.com/fmauquie/react-native-dp3t since react native uses cocoapods by default.