### PR TITLE
Allow registering background sync manager independenty of initialization

### DIFF
--- a/Sources/DP3TSDK/DP3TBackgroundTaskManager.swift
+++ b/Sources/DP3TSDK/DP3TBackgroundTaskManager.swift
@@ -10,6 +10,8 @@ import UIKit.UIApplication
 
 private class SyncOperation: Operation {
     override func main() {
+        guard DP3TTracing.isInitialized else { return }
+
         DP3TTracing.sync { result in
             switch result {
             case .failure:

--- a/Sources/DP3TSDK/DP3TSDK.swift
+++ b/Sources/DP3TSDK/DP3TSDK.swift
@@ -42,6 +42,8 @@ class DP3TSDK {
 
     /// The background task manager. This is marked as Any? because it is only available as of iOS 13 and properties cannot be
     /// marked with @available without causing the whole class to be restricted also.
+    ///
+    /// This can be initialized while initializing the SDK, or preemptively using initializeBackgroundTaskManager()
     private static var backgroundTaskManager: Any? = nil;
 
     /// delegate

--- a/Sources/DP3TSDK/DP3TTracing.swift
+++ b/Sources/DP3TSDK/DP3TTracing.swift
@@ -51,6 +51,12 @@ public enum DP3TTracing {
         }
     }
 
+    /// You have to call this in your onCreate() handler if you do not intend to call DP3TTracing.initialize(), or background task registration will crash your app on iOS > 13
+    /// If you call DP3TTracing.initialize() in your onCreate() handler, this is not useful.
+    public static func preInitialize() {
+        DP3TSDK.initializeBackgroundTaskManager();
+    }
+
     /// initialize the SDK
     /// - Parameters:
     ///   - appId: application identifier used for the discovery call
@@ -145,6 +151,12 @@ public enum DP3TTracing {
         instance = nil
     }
 
+    /// is the SDK initialized ?
+    /// You are not allowed to do anything except initialize if it isn't
+    public static var isInitialized: Bool {
+        return instance != nil
+    }
+
     #if CALIBRATION
         public static func startAdvertising() throws {
             guard let instance = instance else {
@@ -173,10 +185,6 @@ public enum DP3TTracing {
 
         public static func numberOfHandshakes() throws -> Int {
             try instance.numberOfHandshakes()
-        }
-
-        public static var isInitialized: Bool {
-            return instance != nil
         }
 
         public static func getSecretKeyRepresentationForToday() throws -> String {


### PR DESCRIPTION
Background sync manager has to be registered during `onCreate`, but looks like it is the only reason the entire SDK has to be initialized at this time.

Decoupling this is necessary for apps using React Native to initialize the SDK from JavaScript, and would allow me to fix https://github.com/fmauquie/react-native-dp3t-sdk/issues/5 cleanly (right now I initialize the SDK with dummy parameters, then I reset it which removes all data).

- the previous initialization behavior still works
- the previous logging behavior is kept in place
- it guards against `fatalError` when sync is triggered without initializing the SDK
- as an added bonus it will allows us (in React Native) to query SDK initialization status