### PR TITLE
Always remove publish operation after calling getDiagnosisKeys() to m…

### DIFF
--- a/Sources/DP3TSDK/Background/OutstandingPublishOperation.swift
+++ b/Sources/DP3TSDK/Background/OutstandingPublishOperation.swift
@@ -108,6 +108,10 @@ class OutstandingPublishOperation: Operation {
                     } else {
                         logger.error("could not retrieve key")
                     }
+
+                    logger.log("removing publish operation %{public}@ from storage", op.debugDescription)
+                    storage.remove(publish: op)
+
                     self.cancel()
                     return
                 }
@@ -140,6 +144,10 @@ class OutstandingPublishOperation: Operation {
                     if let error = errorHappend {
                         logger.error("error happend while publishing key %{public}@: %{public}@", op.debugDescription, error.localizedDescription)
                     }
+
+                    logger.log("removing publish operation %{public}@ from storage", op.debugDescription)
+                    storage.remove(publish: op)
+
                     self.cancel()
                     return
                 }

--- a/Tests/DP3TSDKTests/OutstandingPublishOperationTests.swift
+++ b/Tests/DP3TSDKTests/OutstandingPublishOperationTests.swift
@@ -247,7 +247,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
 
         operationQueue.addOperations([operationToTest], waitUntilFinished: true)
 
-        XCTAssertEqual(storage.removeCallCount, 0)
+        XCTAssertEqual(storage.removeCallCount, 1)
         XCTAssertEqual(service.addedExposeeListCount, 0)
         XCTAssertEqual(mockManager.fakeAccessedCount, 0)
         XCTAssertEqual(mockManager.realAccessedCount, 1)
@@ -274,7 +274,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
 
         operationQueue.addOperations([operationToTest], waitUntilFinished: true)
 
-        XCTAssertEqual(storage.removeCallCount, 0)
+        XCTAssertEqual(storage.removeCallCount, 1)
         XCTAssertEqual(service.addedExposeeListCount, 1)
         XCTAssertEqual(mockManager.fakeAccessedCount, 1)
         XCTAssertEqual(mockManager.realAccessedCount, 0)


### PR DESCRIPTION
…ake sure consent-popup is never shown more than once for last key