### PR TITLE
Prevent possible deadlock in sync operation

### DIFF
--- a/Sources/DP3TSDK/Networking/KnownCasesSynchronizer.swift
+++ b/Sources/DP3TSDK/Networking/KnownCasesSynchronizer.swift
@@ -40,7 +40,7 @@ class KnownCasesSynchronizer {
 
     private var callbacks: [Callback] = []
 
-    private var backgroundTask: UIBackgroundTaskIdentifier?
+    private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
 
     private var dataTasks: [URLSessionDataTask] = []
 
@@ -88,8 +88,8 @@ class KnownCasesSynchronizer {
             self.callbacks.append(callback)
 
             // If we already have a background task we need to cancel it
-            if let backgroundTask = self.backgroundTask, backgroundTask != .invalid {
-                UIApplication.shared.endBackgroundTask(backgroundTask)
+            if self.backgroundTask != .invalid {
+                UIApplication.shared.endBackgroundTask(self.backgroundTask)
                 self.backgroundTask = .invalid
             }
 
@@ -101,7 +101,7 @@ class KnownCasesSynchronizer {
             self.internalSync(now: now) { [weak self] result in
                 guard let self = self else { return }
                 self.queue.async {
-                    UIApplication.shared.endBackgroundTask(self.backgroundTask!)
+                    UIApplication.shared.endBackgroundTask(self.backgroundTask)
                     self.backgroundTask = .invalid
                     self.callbacks.forEach { $0(result) }
                     self.callbacks.removeAll()

--- a/Sources/DP3TSDK/Networking/KnownCasesSynchronizer.swift
+++ b/Sources/DP3TSDK/Networking/KnownCasesSynchronizer.swift
@@ -95,7 +95,8 @@ class KnownCasesSynchronizer {
 
             self.backgroundTask = UIApplication.shared.beginBackgroundTask(withName: "org.dpppt.sync") { [weak self] in
                 guard let self = self else { return }
-                self.cancelSync()
+                UIApplication.shared.endBackgroundTask(self.backgroundTask)
+                self.backgroundTask = .invalid
             }
 
             self.internalSync(now: now) { [weak self] result in
@@ -111,7 +112,7 @@ class KnownCasesSynchronizer {
     }
 
     func cancelSync() {
-        queue.sync { [weak self] in
+        queue.async { [weak self] in
             guard let self = self else { return }
             self.isCancelled = true
 


### PR DESCRIPTION
- Avoids possible deadlock when `self.queue` is blocked while `detectExposures()` is running and if `queue.sync()` is called from the main thread, the completionHandler of `detectExposures()` (which is scheduled on the main thread) will never be called and we could end up in a deadlock.
- Adds safety-measure to avoid deadlocking by aborting detectExposures() after 3min