### PR TITLE
Adds response data to HTTPFailureReponse case

### DIFF
--- a/Sources/DP3TSDK/DP3TError.swift
+++ b/Sources/DP3TSDK/DP3TError.swift
@@ -45,7 +45,7 @@ public enum DP3TNetworkingError: Error {
     /// The response is not an HTTP response
     case notHTTPResponse
     /// An unexpected HTTP error state was returned
-    case HTTPFailureResponse(status: Int)
+    case HTTPFailureResponse(status: Int, data: Data?)
     /// Response body was not expected to be empty
     case noDataReturned
     /// The returned body could not be parsed. The data might be in the wrong format or corrupted
@@ -77,7 +77,7 @@ public enum DP3TNetworkingError: Error {
             return 600
         case .timeInconsistency:
             return 700
-        case let .HTTPFailureResponse(status: status):
+        case let .HTTPFailureResponse(status: status, data: _):
             // Combines the HTTP Status error with the error
             return 8000 + status
         case .jwtSignatureError(code: let code, debugDescription: _):

--- a/Sources/DP3TSDK/Networking/ExposeeServiceClient.swift
+++ b/Sources/DP3TSDK/Networking/ExposeeServiceClient.swift
@@ -146,7 +146,7 @@ class ExposeeServiceClient: ExposeeServiceClientProtocol {
                 completion(.success(.init(data: nil, publishedUntil: publishedUntil)))
                 return
             default:
-                completion(.failure(.HTTPFailureResponse(status: httpStatus)))
+                completion(.failure(.HTTPFailureResponse(status: httpStatus, data: data)))
                 return
             }
 
@@ -200,7 +200,7 @@ class ExposeeServiceClient: ExposeeServiceClientProtocol {
         }
         request.httpBody = payload
 
-        let task = urlSession.dataTask(with: request, completionHandler: { _, response, error in
+        let task = urlSession.dataTask(with: request, completionHandler: { data, response, error in
             guard error == nil else {
                 completion(.failure(.networkSessionError(error: error!)))
                 return
@@ -212,7 +212,7 @@ class ExposeeServiceClient: ExposeeServiceClientProtocol {
 
             let statusCode = httpResponse.statusCode
             guard statusCode == 200 else {
-                completion(.failure(.HTTPFailureResponse(status: statusCode)))
+                completion(.failure(.HTTPFailureResponse(status: statusCode, data: data)))
                 return
             }
 
@@ -246,7 +246,7 @@ class ExposeeServiceClient: ExposeeServiceClientProtocol {
         }
         request.httpBody = payload
 
-        let task = urlSession.dataTask(with: request, completionHandler: { _, response, error in
+        let task = urlSession.dataTask(with: request, completionHandler: { data, response, error in
             guard error == nil else {
                 completion(.failure(.networkSessionError(error: error!)))
                 return
@@ -258,7 +258,7 @@ class ExposeeServiceClient: ExposeeServiceClientProtocol {
 
             let statusCode = httpResponse.statusCode
             guard statusCode == 200 else {
-                completion(.failure(.HTTPFailureResponse(status: statusCode)))
+                completion(.failure(.HTTPFailureResponse(status: statusCode, data: data)))
                 return
             }
 

--- a/Tests/DP3TSDKTests/KnownCasesSynchronizerTests.swift
+++ b/Tests/DP3TSDKTests/KnownCasesSynchronizerTests.swift
@@ -292,7 +292,7 @@ final class KnownCasesSynchronizerTests: XCTestCase {
         let matcher = MockMatcher()
         let service = MockService()
         let defaults = MockDefaults()
-        service.error = .HTTPFailureResponse(status: 400)
+        service.error = .HTTPFailureResponse(status: 400, data: nil)
         service.errorAfter = 5
         let sync = KnownCasesSynchronizer(matcher: matcher,
                                           service: service,


### PR DESCRIPTION
It allows  to show the error response, if supplied, to the end user. 
It helps in debugging.
The parsing of the response is left to the app that implements the SDK, since the responses can differ from one service to another.

Downside is that this change will break any code that switches `DP3TNetworkingError`. Developers need to update the associated value tuple of `HTTPFailureResponse` to support 2 values.