### PR TITLE
Also retrieve last TEK in background task on iOS > 13.6

### DIFF
--- a/Sources/DP3TSDK/Background/OutstandingPublishOperation.swift
+++ b/Sources/DP3TSDK/Background/OutstandingPublishOperation.swift
@@ -56,10 +56,15 @@ class OutstandingPublishOperation: Operation {
                     continue
                 }
 
-                if runningInBackground {
-                    // skip publish if we are not in foreground since apple does not allow calles to EN.getDiagnosisKeys in background
-                    logger.log("skipping outstanding key %{public}@ because we are not in foreground", op.debugDescription)
-                    continue
+                if #available(iOS 13.6, *) {
+                    // this was fixed by apple with iOS 13.6 beta 4
+                    // (there is unfortunally no way to negate #available checks)
+                } else {
+                    if runningInBackground {
+                        // skip publish if we are not in foreground since apple does not allow calles to EN.getDiagnosisKeys in background
+                        logger.log("skipping outstanding key %{public}@ because we are not in foreground", op.debugDescription)
+                        continue
+                    }
                 }
 
                 logger.log("handling outstanding Publish %@", op.debugDescription)


### PR DESCRIPTION
On iOS 13.5.x, calling ENManager.getDiagnosisKeys() to retrieve the last key on the following day from a background task results in an error (ENErrorCodeAPIMisuse). This was fixed by Apple in iOS 13.6 (#FB7733003).