### PR TITLE
Calibration app improvements

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -2,7 +2,7 @@ name: distribute
 
 on:
    push:		
-     branches: [ master, master-alpha ]
+     branches: [ master, master-alpha, develop ]
 jobs:
   appcenter:
     runs-on: macOS-latest

--- a/SampleApp/DP3TSampleApp/ControlViewController.swift
+++ b/SampleApp/DP3TSampleApp/ControlViewController.swift
@@ -251,7 +251,7 @@ class ControlViewController: UIViewController {
                 uploadKeysButton.setTitleColor(.blue, for: .normal)
                 uploadKeysButton.setTitleColor(.black, for: .highlighted)
             }
-            uploadKeysButton.setTitle("Upload Keys for Debugging", for: .normal)
+            uploadKeysButton.setTitle("Upload Keys for Experiment", for: .normal)
             uploadKeysButton.addTarget(self, action: #selector(uploadKeys), for: .touchUpInside)
             stackView.addArrangedSubview(uploadKeysButton)
         }

--- a/SampleApp/DP3TSampleApp/ControlViewController.swift
+++ b/SampleApp/DP3TSampleApp/ControlViewController.swift
@@ -361,8 +361,14 @@ class ControlViewController: UIViewController {
             guard let deviceName = deviceNameTextField.text, !deviceName.isEmpty,
                   let experimentName = experimentNameTextField.text, !experimentName.isEmpty else {
                     var errors: [String] = []
-                    if deviceNameTextField.text == nil || deviceNameTextField.text!.isEmpty { errors.append("device name") }
-                    if experimentNameTextField.text == nil || experimentNameTextField.text!.isEmpty { errors.append("experiment name") }
+                    if deviceNameTextField.text == nil ||
+                        deviceNameTextField.text!.isEmpty {
+                        errors.append("device name")
+                    }
+                    if experimentNameTextField.text == nil ||
+                        experimentNameTextField.text!.isEmpty {
+                        errors.append("experiment name")
+                    }
 
                     let errorAlert = UIAlertController(title: "Error", message: "Please provide \(errors.joined(separator: " and "))", preferredStyle: .alert)
                     errorAlert.addAction(.init(title: "OK", style: .default) { _ in

--- a/SampleApp/DP3TSampleApp/KeysViewController.swift
+++ b/SampleApp/DP3TSampleApp/KeysViewController.swift
@@ -48,7 +48,9 @@ class KeysViewController: UIViewController {
 
     private let networkingHelper = NetworkingHelper()
 
-    let activityIndicator = UIActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
+    private let activityIndicator = UIActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
+
+    private let nameRegex = try? NSRegularExpression(pattern: "key_export_experiment_([a-zA-Z0-9]+)_(.+)", options: .caseInsensitive)
 
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -96,78 +98,53 @@ class KeysViewController: UIViewController {
         let roundendTs = Date(timeIntervalSince1970: ts - ts.truncatingRemainder(dividingBy: 60 * 60 * 24))
         let date = roundendTs.addingTimeInterval(60 * 60 * 24)
         datePicker.setDate(date, animated: false)
-        loadKey(for: date)
+        loadKeys(for: date)
     }
 
-    func loadKey(for date: Date) {
+    private func parseZipName(name: String) -> (experimentName: String?, deviceName: String?) {
+        guard let regex = nameRegex else { return (nil, nil) }
+        var experimentName: String?
+        var deviceName: String?
+
+        if let match = regex.firstMatch(in: name, options: [], range: NSRange(location: 0, length: name.utf16.count)) {
+            if let experimentRange = Range(match.range(at: 1), in: name) {
+                experimentName = String(name[experimentRange])
+            }
+
+            if let deviceRange = Range(match.range(at: 2), in: name) {
+                deviceName = String(name[deviceRange])
+            }
+        }
+        return (experimentName, deviceName)
+    }
+
+    private func groupZips(zips: [NetworkingHelper.DebugZips], date: Date) -> [KeySection: [NetworkingHelper.DebugZips]] {
+        return zips.reduce([KeySection: [NetworkingHelper.DebugZips]]()) { (result, zip) -> [KeySection : [NetworkingHelper.DebugZips]] in
+            let (experimentName, _) = self.parseZipName(name: zip.name)
+            let section = KeySection(date: date, experimentName: experimentName)
+            var mutatingResult = result
+            mutatingResult[section, default: []].append(zip)
+            return mutatingResult
+        }
+    }
+
+    func loadKeys(for date: Date) {
         activityIndicator.startAnimating()
         networkingHelper.getDebugKeys(day: date) { [weak self] result in
             guard let self = self else { return }
             defer { self.activityIndicator.stopAnimating() }
             var snapshot = self.dataSource.snapshot()
 
-            let pattern = "key_export_experiment_([a-zA-Z0-9]+)_(.+)"
-            guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else { return }
-
-            let grouped = result.reduce([KeySection: [NetworkingHelper.DebugZips]]()) { (result, zip) -> [KeySection : [NetworkingHelper.DebugZips]] in
-                var experimentName: String? = nil
-                //var deviceName: String?
-
-                if let match = regex.firstMatch(in: zip.name, options: [], range: NSRange(location: 0, length: zip.name.utf16.count)) {
-                    if let experimentRange = Range(match.range(at: 1), in: zip.name) {
-                        experimentName = String(zip.name[experimentRange])
-                    }
-
-                    /*if let deviceRange = Range(match.range(at: 2), in: zip.name) {
-                        deviceName = zip.name[deviceRange]
-                    }*/
-                }
-
-                let section = KeySection(date: date, experimentName: experimentName)
-                var mutatingResult = result
-                mutatingResult[section, default: []].append(zip)
-                return mutatingResult
-            }
+            let grouped = self.groupZips(zips: result, date: date)
 
             for groupedItem in grouped {
                 let section = groupedItem.key
-                if !snapshot.sectionIdentifiers.contains(section) {
-                    var inserted = false
-                    for s in snapshot.sectionIdentifiers {
-                        if !inserted, date > s.date, (section.experimentName == nil && s.experimentName == nil) || section.experimentName! > s.experimentName! {
-                            snapshot.insertSections([section], beforeSection: s)
-                            inserted = true
-                            continue
-                        }
-                    }
-                    if !inserted {
-                        snapshot.appendSections([section])
-                    }
-                }
-                let existingNames = snapshot.itemIdentifiers(inSection: section).map(\.name)
-                for zip in groupedItem.value {
-                    if !existingNames.contains(zip.name) {
-                        snapshot.appendItems([zip], toSection: section)
-                    }
-                }
+                snapshot.insert(section: section, items: groupedItem.value)
             }
 
             if grouped.isEmpty {
                 let section = KeySection(date: date, experimentName: nil)
-                if !snapshot.sectionIdentifiers.contains(section) {
-                    var inserted = false
-                    for s in snapshot.sectionIdentifiers {
-                        if !inserted, date > s.date {
-                            snapshot.insertSections([section], beforeSection: s)
-                            inserted = true
-                            continue
-                        }
-                    }
-                    if !inserted {
-                        snapshot.appendSections([section])
-                    }
-                }
-                snapshot.appendItems([], toSection: section)
+                snapshot.insert(section: section, items: [])
             }
 
             self.dataSource.apply(snapshot, animatingDifferences: true)
@@ -176,7 +153,7 @@ class KeysViewController: UIViewController {
 
     @objc func datePickerDidChange() {
         let date = datePicker.date
-        loadKey(for: date)
+        loadKeys(for: date)
     }
 
     func makeDataSource() -> KeyDiffableDataSource {
@@ -255,5 +232,31 @@ extension ENExposureConfiguration {
         configuration.metadata = ["attenuationDurationThresholds": [parameters.contactMatching.lowerThreshold,
                                                                     parameters.contactMatching.higherThreshold]]
         return configuration
+    }
+}
+
+extension NSDiffableDataSourceSnapshot where SectionIdentifierType == KeySection,ItemIdentifierType == NetworkingHelper.DebugZips {
+    mutating func insert(section: KeySection, items: [NetworkingHelper.DebugZips]) {
+        if !sectionIdentifiers.contains(section) {
+            var inserted = false
+            for s in sectionIdentifiers {
+                if !inserted,
+                    section.date > s.date,
+                    (section.experimentName == nil && s.experimentName == nil) || section.experimentName! > s.experimentName! {
+                    insertSections([section], beforeSection: s)
+                    inserted = true
+                    break
+                }
+            }
+            if !inserted {
+                appendSections([section])
+            }
+        }
+        let existingNames = itemIdentifiers(inSection: section).map(\.name)
+        for zip in items {
+            if !existingNames.contains(zip.name) {
+                appendItems([zip], toSection: section)
+            }
+        }
     }
 }

--- a/SampleApp/DP3TSampleApp/KeysViewController.swift
+++ b/SampleApp/DP3TSampleApp/KeysViewController.swift
@@ -134,7 +134,7 @@ class KeysViewController: UIViewController {
                 if !snapshot.sectionIdentifiers.contains(section) {
                     var inserted = false
                     for s in snapshot.sectionIdentifiers {
-                        if !inserted, date > s.date {
+                        if !inserted, date > s.date, (section.experimentName == nil && s.experimentName == nil) || section.experimentName! > s.experimentName! {
                             snapshot.insertSections([section], beforeSection: s)
                             inserted = true
                             continue

--- a/SampleApp/DP3TSampleApp/KeysViewController.swift
+++ b/SampleApp/DP3TSampleApp/KeysViewController.swift
@@ -242,7 +242,7 @@ extension NSDiffableDataSourceSnapshot where SectionIdentifierType == KeySection
             for s in sectionIdentifiers {
                 if !inserted,
                     section.date > s.date,
-                    (section.experimentName == nil && s.experimentName == nil) || section.experimentName! > s.experimentName! {
+                    (section.experimentName == nil || s.experimentName == nil) || section.experimentName! > s.experimentName! {
                     insertSections([section], beforeSection: s)
                     inserted = true
                     break


### PR DESCRIPTION
A second textfield was added to specify the experiment name when uploading the key.
In the key table view the entries now get grouped by experiment name and date.
Distribution to appcenter now also happens on develop push.