### PR TITLE
filter EN keys to 14 days

### DIFF
--- a/SampleApp/DP3TSampleApp/ControlViewController.swift
+++ b/SampleApp/DP3TSampleApp/ControlViewController.swift
@@ -282,7 +282,7 @@ class ControlViewController: UIViewController {
     }
 
     @objc func setExposed() {
-        // Share keys of last numberOfKeysToSubmit days
+        // Share keys of last 14 days
         DP3TTracing.iWasExposed(onset: Date(timeIntervalSinceNow: -60 * 60 * 24 * 14), authentication: .none) { [weak self] result in
             switch result {
             case let .failure(error):

--- a/Sources/DP3TSDK/Cryptography/DiagnosisKeysProvider.swift
+++ b/Sources/DP3TSDK/Cryptography/DiagnosisKeysProvider.swift
@@ -74,7 +74,11 @@ extension ENManager: DiagnosisKeysProvider {
                 completionHandler(.failure(.exposureNotificationError(error: error)))
             } else if let keys = keys {
                 logger.log("received %d keys", keys.count)
-                var filteredKeys = keys
+
+                let oldestDate = DayDate(date: Date().addingTimeInterval(-Default.shared.parameters.crypto.maxAgeOfKeyToRetreive)).dayMin
+
+                // make sure to never retreive keys older than maxNumberOfDaysToRetreive even if the onset date is older
+                var filteredKeys = keys.filter { $0.date > oldestDate }
 
                 // if a onsetDate was passed we filter the keys using it
                 if let onsetDate = onsetDate {

--- a/Sources/DP3TSDK/DP3TParameters.swift
+++ b/Sources/DP3TSDK/DP3TParameters.swift
@@ -12,7 +12,7 @@ import CoreBluetooth
 import Foundation
 
 public struct DP3TParameters: Codable {
-    static let parameterVersion: Int = 13
+    static let parameterVersion: Int = 14
 
     let version: Int
 
@@ -32,6 +32,8 @@ public struct DP3TParameters: Codable {
         public var timeZone: TimeZone = TimeZone(identifier: "UTC")!
 
         public var numberOfDaysToKeepMatchedContacts = 10
+
+        public var maxAgeOfKeyToRetreive: TimeInterval = .day * 14
 
         public var numberOfKeysToSubmit: Int = 30
     }

--- a/Tests/DP3TSDKTests/DP3TSDKTests.swift
+++ b/Tests/DP3TSDKTests/DP3TSDKTests.swift
@@ -52,7 +52,11 @@ class DP3TSDKTests: XCTestCase {
     fileprivate var service: MockService!
     fileprivate var defaults: MockDefaults!
     fileprivate var keyProvider: MockKeyProvider!
-    fileprivate var descriptor: ApplicationDescriptor!
+
+    var descriptor: ApplicationDescriptor {
+        MockService.descriptor
+    }
+
     fileprivate var backgroundTaskManager: DP3TBackgroundTaskManager!
     fileprivate var manager: MockENManager!
     fileprivate var exposureDayStorage: ExposureDayStorage!
@@ -71,7 +75,6 @@ class DP3TSDKTests: XCTestCase {
 
         service = MockService()
         keyProvider = MockKeyProvider()
-        descriptor = ApplicationDescriptor(appId: "org.dpppt", bucketBaseUrl: URL(string: "http://google.com")!, reportBaseUrl: URL(string: "http://google.com")!)
         backgroundTaskManager = DP3TBackgroundTaskManager(handler: nil, keyProvider: keyProvider, serviceClient: service, tracer: tracer)
         sdk = DP3TSDK(applicationDescriptor: descriptor,
                           urlSession: MockSession(data: nil, urlResponse: nil, error: nil),

--- a/Tests/DP3TSDKTests/DiagnosisKeysProviderTests.swift
+++ b/Tests/DP3TSDKTests/DiagnosisKeysProviderTests.swift
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+@testable import DP3TSDK
+import Foundation
+import XCTest
+import ExposureNotification
+
+class DiagnosisKeysProviderTests: XCTestCase {
+
+    var manager: MockENManager!
+    var descriptor: ApplicationDescriptor!
+
+    override func setUp() {
+        manager = MockENManager()
+        descriptor = ApplicationDescriptor(appId: "org.dpppt", bucketBaseUrl: URL(string: "http://google.com")!, reportBaseUrl: URL(string: "http://google.com")!)
+    }
+
+    func testFilteringOfOldTests(){
+        let onset = Date().addingTimeInterval(.day * -100)
+        let day = DayDate(date: Date().addingTimeInterval(.day * (-15)))
+        manager.keys = [.initialize(rollingStartNumber: day.period)]
+
+        let exp = expectation(description: "getDiagnosisKeys")
+        manager.getDiagnosisKeys(onsetDate: onset, appDesc: descriptor) { (result) in
+            switch result {
+            case .failure(_):
+                XCTFail()
+            case let .success(keys):
+                XCTAssert(keys.isEmpty)
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 0.1)
+    }
+
+    func testNotFilteringNewTests(){
+        let onset = Date().addingTimeInterval(.day * -14)
+        let day = DayDate(date: Date().addingTimeInterval(.day * (-13)))
+        manager.keys = [.initialize(rollingStartNumber: day.period)]
+
+        let exp = expectation(description: "getDiagnosisKeys")
+        manager.getDiagnosisKeys(onsetDate: onset, appDesc: descriptor) { (result) in
+            switch result {
+            case .failure(_):
+                XCTFail()
+            case let .success(keys):
+                XCTAssert(!keys.isEmpty)
+                XCTAssertEqual(keys.count, 1)
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 0.1)
+    }
+
+    func testFilteringOnsetDate(){
+        let onset = Date().addingTimeInterval(.day * -13)
+        let day = DayDate(date: Date().addingTimeInterval(.day * (-14)))
+        manager.keys = [.initialize(rollingStartNumber: day.period)]
+
+        let exp = expectation(description: "getDiagnosisKeys")
+        manager.getDiagnosisKeys(onsetDate: onset, appDesc: descriptor) { (result) in
+            switch result {
+            case .failure(_):
+                XCTFail()
+            case let .success(keys):
+                XCTAssert(keys.isEmpty)
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 0.1)
+    }
+    
+}
+
+extension ENTemporaryExposureKey {
+    static func initialize(data: Data = Data(capacity: 16),
+                           rollingPeriod: ENIntervalNumber = UInt32(TimeInterval.day / (.minute * 10)),
+                           rollingStartNumber: ENIntervalNumber,
+                           transmissionRiskLevel: ENRiskLevel = 0 ) -> ENTemporaryExposureKey {
+        let key = ENTemporaryExposureKey()
+        key.keyData = data
+        key.rollingPeriod = rollingPeriod
+        key.rollingStartNumber = rollingStartNumber
+        key.transmissionRiskLevel = transmissionRiskLevel
+        return key
+    }
+}

--- a/Tests/DP3TSDKTests/DiagnosisKeysProviderTests.swift
+++ b/Tests/DP3TSDKTests/DiagnosisKeysProviderTests.swift
@@ -16,11 +16,12 @@ import ExposureNotification
 class DiagnosisKeysProviderTests: XCTestCase {
 
     var manager: MockENManager!
-    var descriptor: ApplicationDescriptor!
+    var descriptor: ApplicationDescriptor {
+        MockService.descriptor
+    }
 
     override func setUp() {
         manager = MockENManager()
-        descriptor = ApplicationDescriptor(appId: "org.dpppt", bucketBaseUrl: URL(string: "http://google.com")!, reportBaseUrl: URL(string: "http://google.com")!)
     }
 
     func testFilteringOfOldTests(){

--- a/Tests/DP3TSDKTests/Mocks/MockENManager.swift
+++ b/Tests/DP3TSDKTests/Mocks/MockENManager.swift
@@ -84,6 +84,12 @@ class MockENManager: ENManager {
     override class var authorizationStatus: ENAuthorizationStatus {
         Self.authStatus
     }
+
+    var keys: [ENTemporaryExposureKey] = []
+
+    override func getDiagnosisKeys(completionHandler: @escaping ENGetDiagnosisKeysHandler) {
+        completionHandler(keys, nil)
+    }
 }
 
 class MockSummary: ENExposureDetectionSummary {

--- a/Tests/DP3TSDKTests/Mocks/MockService.swift
+++ b/Tests/DP3TSDKTests/Mocks/MockService.swift
@@ -13,7 +13,11 @@ import Foundation
 
 class MockService: ExposeeServiceClientProtocol {
 
-    var descriptor: ApplicationDescriptor = .init(appId: "org.dpppt", bucketBaseUrl: URL(string: "http://google.com")!, reportBaseUrl: URL(string: "http://google.com")!)
+    static var descriptor: ApplicationDescriptor = .init(appId: "org.dpppt", bucketBaseUrl: URL(string: "http://google.com")!, reportBaseUrl: URL(string: "http://google.com")!)
+
+    var descriptor: ApplicationDescriptor {
+        Self.descriptor
+    }
 
     var requests: [Date] = []
     let session = MockSession(data: "Data".data(using: .utf8), urlResponse: nil, error: nil)

--- a/Tests/DP3TSDKTests/OutstandingPublishOperationTests.swift
+++ b/Tests/DP3TSDKTests/OutstandingPublishOperationTests.swift
@@ -56,11 +56,7 @@ private class ExposeeServiceClientMock: ExposeeServiceClient {
     var addedExposeeListCount: Int = 0
 
     init() {
-        let descriptor = ApplicationDescriptor(appId: "XCD",
-                                               bucketBaseUrl: URL(string: "https://ubique.ch")!,
-                                               reportBaseUrl: URL(string: "https://ubique.ch")!,
-                                               jwtPublicKey: nil,
-                                               mode: .test)
+        let descriptor = MockService.descriptor
         let session = MockSession(data: nil, urlResponse: nil, error: nil)
         super.init(descriptor: descriptor, urlSession: session, urlCache: .shared)
     }


### PR DESCRIPTION
- removes misleading comment

In the sample app, it is hardcoded to submit the last 14 days of keys.
Inside the SDK the parameter numberOfKeysToSubmit is used to pad the submitted keys always to the same length.

- Exposure Notification Framework keeps data for 14 days
This PR adds a parameter that lets us specify the maxAgeOfKeyToRetreive from the ENFramework. This value defaults to 14.