### PR TITLE
increase numberOfDaysToKeepMatchedContacts to 14

### DIFF
--- a/Sources/DP3TSDK/DP3TParameters.swift
+++ b/Sources/DP3TSDK/DP3TParameters.swift
@@ -12,7 +12,7 @@ import CoreBluetooth
 import Foundation
 
 public struct DP3TParameters: Codable {
-    static let parameterVersion: Int = 14
+    static let parameterVersion: Int = 15
 
     let version: Int
 
@@ -31,7 +31,7 @@ public struct DP3TParameters: Codable {
 
         public var timeZone: TimeZone = TimeZone(identifier: "UTC")!
 
-        public var numberOfDaysToKeepMatchedContacts = 10
+        public var numberOfDaysToKeepMatchedContacts = 14
 
         public var maxAgeOfKeyToRetreive: TimeInterval = .day * 14
 


### PR DESCRIPTION
to be consistent with android.
This parameter defines how many days the SDK keeps exposure notifications and the infection status. Everything older than numberOfDaysToKeepMatchedContacts will be discarded.