### PR TITLE
improves next day key release

### DIFF
--- a/Sources/DP3TSDK/DP3TSDK.swift
+++ b/Sources/DP3TSDK/DP3TSDK.swift
@@ -186,19 +186,20 @@ class DP3TSDK {
         OperationQueue().addOperation(outstandingPublishOperation)
 
         let sync = {
+            var storedResult: SyncResult?
+
             // Skip sync when tracing is not active
             if self.state.trackingState != .active {
                 self.log.error("Skip sync when tracking is not active")
-                callback?(.skipped)
-                return
+                storedResult = .skipped
+            } else {
+                group.enter()
+                self.synchronizer.sync { result in
+                    storedResult = result
+                    group.leave()
+                }
             }
 
-            group.enter()
-            var storedResult: SyncResult?
-            self.synchronizer.sync { result in
-                storedResult = result
-                group.leave()
-            }
             group.notify(queue: .main) { [weak self] in
                 guard let self = self else { return }
                 switch storedResult! {


### PR DESCRIPTION
This PR makes sure that the background task keeps running until the outstandingPublishOperation is finished. In some cases, it could happen that the background task was finished before all request for the outstandingPublishOperation were completed.