### PR TITLE
fixes issue of current day key export for iOS >= 13.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - name: Switch to Xcode 11.6
-      run: sudo xcode-select --switch /Applications/Xcode_11.6.app
+    - name: Switch to Xcode 11.7
+      run: sudo xcode-select --switch /Applications/Xcode_11.7.app
 
     # Generate xcode project
     - name: Generate xcodeproj
@@ -32,8 +32,8 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - name: Switch to Xcode 11.6
-      run: sudo xcode-select --switch /Applications/Xcode_11.6.app
+    - name: Switch to Xcode 11.7
+      run: sudo xcode-select --switch /Applications/Xcode_11.7.app
 
     # Compile sample app for iOS Simulator (no signing)
     - name: Compile and run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
     # Compile project and run tests
     - name: Compile and run tests
-      run: fastlane scan
+      run: fastlane scan --disable_concurrent_testing true
 
   sampleapp:
     runs-on: macOS-latest

--- a/.github/workflows/deploy_to_cocoapods.yml
+++ b/.github/workflows/deploy_to_cocoapods.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Switch to Xcode 11.6
-      run: sudo xcode-select --switch /Applications/Xcode_11.6.app
+    - name: Switch to Xcode 11.7
+      run: sudo xcode-select --switch /Applications/Xcode_11.7.app
     
     - name: Install Cocoapods
       run: gem install cocoapods

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -11,8 +11,8 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - name: Switch to Xcode 11.6
-      run: sudo xcode-select --switch /Applications/Xcode_11.6.app
+    - name: Switch to Xcode 11.7
+      run: sudo xcode-select --switch /Applications/Xcode_11.7.app
       
     - name: Run fastlane build
       env:

--- a/SampleApp/DP3TSampleApp/ControlViewController.swift
+++ b/SampleApp/DP3TSampleApp/ControlViewController.swift
@@ -407,7 +407,15 @@ class ControlViewController: UIViewController {
     }
 
     @objc func resetInfectionState() {
-        try? DP3TTracing.resetInfectionStatus()
+        do {
+            try DP3TTracing.resetInfectionStatus()
+        } catch let error as DP3TTracingError {
+            let ac = UIAlertController(title: "Error",
+                                       message: error.description,
+                                       preferredStyle: .alert)
+            ac.addAction(.init(title: "OK", style: .destructive))
+            self.present(ac, animated: true)
+        } catch {}
     }
 
     @objc func resetExposureDays() {
@@ -544,6 +552,8 @@ extension DP3TTracingError {
             return "exposureNotificationError \(error.localizedDescription)"
         case .cancelled:
             return "cancelled"
+        case .infectionStatusNotResettable:
+            return "infectionStatusNotResettable"
         }
     }
 }

--- a/Sources/DP3TSDK/Background/DP3TBackgroundTaskManager.swift
+++ b/Sources/DP3TSDK/Background/DP3TBackgroundTaskManager.swift
@@ -130,7 +130,8 @@ class DP3TBackgroundTaskManager {
 
         let outstandingPublishOperation = OutstandingPublishOperation(keyProvider: keyProvider,
                                                                       serviceClient: serviceClient,
-                                                                      runningInBackground: true)
+                                                                      runningInBackground: true,
+                                                                      tracer: tracer)
         completionGroup.enter()
         outstandingPublishOperation.completionBlock = {
             completionGroup.leave()

--- a/Sources/DP3TSDK/Background/OutstandingPublishOperation.swift
+++ b/Sources/DP3TSDK/Background/OutstandingPublishOperation.swift
@@ -69,6 +69,7 @@ class OutstandingPublishOperation: Operation {
                     if #available(iOS 13.7, *), !op.fake {
                         tracer.setEnabled(false, completionHandler: nil)
                     }
+                    enableResettingOfInfectionStatus(fake: op.fake)
                     continue
                 }
 
@@ -136,10 +137,7 @@ class OutstandingPublishOperation: Operation {
                         logger.error("could not retrieve key")
                     }
 
-                    if op.fake == false {
-                        logger.log("enabling resetting of infection status")
-                        defaults.infectionStatusIsResettable = true
-                    }
+                    enableResettingOfInfectionStatus(fake: op.fake)
 
                     logger.log("removing publish operation %{public}@ from storage", op.debugDescription)
                     storage.remove(publish: op)
@@ -180,10 +178,7 @@ class OutstandingPublishOperation: Operation {
                     logger.log("removing publish operation %{public}@ from storage", op.debugDescription)
                     storage.remove(publish: op)
 
-                    if op.fake == false {
-                        logger.log("enabling resetting of infection status")
-                        defaults.infectionStatusIsResettable = true
-                    }
+                    enableResettingOfInfectionStatus(fake: op.fake)
 
                     self.cancel()
                     return
@@ -191,11 +186,15 @@ class OutstandingPublishOperation: Operation {
                 logger.log("successfully published %{public}@ removing publish from storage", op.debugDescription)
                 storage.remove(publish: op)
 
-                if op.fake == false {
-                    self.logger.log("enabling resetting of infection status")
-                    self.defaults.infectionStatusIsResettable = true
-                }
+                enableResettingOfInfectionStatus(fake: op.fake)
             }
+        }
+    }
+    
+    fileprivate func enableResettingOfInfectionStatus(fake: Bool){
+        if !fake {
+            self.logger.log("enabling resetting of infection status")
+            self.defaults.infectionStatusIsResettable = true
         }
     }
 }

--- a/Sources/DP3TSDK/Background/OutstandingPublishOperation.swift
+++ b/Sources/DP3TSDK/Background/OutstandingPublishOperation.swift
@@ -20,17 +20,28 @@ class OutstandingPublishOperation: Operation {
 
     private let runningInBackground: Bool
 
+    private var defaults: DefaultStorage
+
+    private var tracer: Tracer
+
     var now: Date {
         .init()
     }
 
     static let serialQueue = DispatchQueue(label: "org.dpppt.outstandingPublishQueue")
 
-    init(keyProvider: DiagnosisKeysProvider, serviceClient: ExposeeServiceClientProtocol, storage: OutstandingPublishStorage = OutstandingPublishStorage(), runningInBackground: Bool) {
+    init(keyProvider: DiagnosisKeysProvider,
+         serviceClient: ExposeeServiceClientProtocol,
+         storage: OutstandingPublishStorage = OutstandingPublishStorage(),
+         runningInBackground: Bool,
+         defaults: DefaultStorage = Default.shared,
+         tracer: Tracer) {
         self.keyProvider = keyProvider
         self.serviceClient = serviceClient
         self.storage = storage
         self.runningInBackground = runningInBackground
+        self.defaults = defaults
+        self.tracer = tracer
     }
 
     override func main() {
@@ -53,6 +64,11 @@ class OutstandingPublishOperation: Operation {
                     // ignore outstanding keys older than one day, upload token will be invalid
                     logger.log("skipping outstanding key %{public}@ because of age and removing publish from storage", op.debugDescription)
                     storage.remove(publish: op)
+
+                    // if we are running on iOS > 13.7 we need to disable the tracing
+                    if #available(iOS 13.7, *), !op.fake {
+                        tracer.setEnabled(false, completionHandler: nil)
+                    }
                     continue
                 }
 
@@ -88,7 +104,13 @@ class OutstandingPublishOperation: Operation {
                 } else {
                     // get all keys up until today
                     group.enter()
-                    keyProvider.getDiagnosisKeys(onsetDate: nil, appDesc: serviceClient.descriptor) { result in
+
+                    // if we are running on iOS > 13.7 we need to disable the tracing after retreiving the key
+                    var disableAfterCompletion = false
+                    if #available(iOS 13.7, *) {
+                        disableAfterCompletion = true
+                    }
+                    keyProvider.getDiagnosisKeys(onsetDate: nil, appDesc: serviceClient.descriptor, disableExposureNotificationAfterCompletion: disableAfterCompletion) { result in
                         switch result {
                         case let .success(keys):
                             let rollingStartNumber = DayDate(date: op.dayToPublish).period
@@ -112,6 +134,11 @@ class OutstandingPublishOperation: Operation {
                         }
                     } else {
                         logger.error("could not retrieve key")
+                    }
+
+                    if op.fake == false {
+                        logger.log("enabling resetting of infection status")
+                        defaults.infectionStatusIsResettable = true
                     }
 
                     logger.log("removing publish operation %{public}@ from storage", op.debugDescription)
@@ -153,11 +180,21 @@ class OutstandingPublishOperation: Operation {
                     logger.log("removing publish operation %{public}@ from storage", op.debugDescription)
                     storage.remove(publish: op)
 
+                    if op.fake == false {
+                        logger.log("enabling resetting of infection status")
+                        defaults.infectionStatusIsResettable = true
+                    }
+
                     self.cancel()
                     return
                 }
                 logger.log("successfully published %{public}@ removing publish from storage", op.debugDescription)
                 storage.remove(publish: op)
+
+                if op.fake == false {
+                    self.logger.log("enabling resetting of infection status")
+                    self.defaults.infectionStatusIsResettable = true
+                }
             }
         }
     }

--- a/Sources/DP3TSDK/Cryptography/DiagnosisKeysProvider.swift
+++ b/Sources/DP3TSDK/Cryptography/DiagnosisKeysProvider.swift
@@ -16,7 +16,7 @@ protocol DiagnosisKeysProvider: class {
 
     func getFakeKeys(count: Int, startingFrom: Date) -> [CodableDiagnosisKey]
 
-    func getDiagnosisKeys(onsetDate: Date?, appDesc: ApplicationDescriptor, completionHandler: @escaping (Result<[CodableDiagnosisKey], DP3TTracingError>) -> Void)
+    func getDiagnosisKeys(onsetDate: Date?, appDesc: ApplicationDescriptor, disableExposureNotificationAfterCompletion: Bool, completionHandler: @escaping (Result<[CodableDiagnosisKey], DP3TTracingError>) -> Void)
 }
 
 extension DiagnosisKeysProvider {
@@ -41,7 +41,7 @@ extension DiagnosisKeysProvider {
 fileprivate var logger = Logger(.main, category: "DiagnosisKeysProvider")
 
 extension ENManager: DiagnosisKeysProvider {
-    func getDiagnosisKeys(onsetDate: Date?, appDesc: ApplicationDescriptor, completionHandler: @escaping (Result<[CodableDiagnosisKey], DP3TTracingError>) -> Void) {
+    func getDiagnosisKeys(onsetDate: Date?, appDesc: ApplicationDescriptor, disableExposureNotificationAfterCompletion: Bool, completionHandler: @escaping (Result<[CodableDiagnosisKey], DP3TTracingError>) -> Void) {
         logger.trace()
         if !exposureNotificationEnabled {
             // Enable exposure notifications first, if currently not enabled (e.g. last day key)
@@ -55,8 +55,7 @@ extension ENManager: DiagnosisKeysProvider {
                 }
             }
         } else {
-            // Do not disable if it's currently already enabled
-            self.getDiagnosisKeysInternal(onsetDate: onsetDate, appDesc: appDesc, disableExposureNotificationAfterCompletion: false, completionHandler: completionHandler)
+            self.getDiagnosisKeysInternal(onsetDate: onsetDate, appDesc: appDesc, disableExposureNotificationAfterCompletion: disableExposureNotificationAfterCompletion, completionHandler: completionHandler)
         }
     }
 

--- a/Sources/DP3TSDK/DP3TError.swift
+++ b/Sources/DP3TSDK/DP3TError.swift
@@ -36,6 +36,9 @@ public enum DP3TTracingError: Error {
 
     /// The user was marked as infected
     case userAlreadyMarkedAsInfected
+
+    /// the infection status is not resettable currently
+    case infectionStatusNotResettable
 }
 
 /// A set of networking errors returned from the SDK

--- a/Sources/DP3TSDK/DP3TTracing.swift
+++ b/Sources/DP3TSDK/DP3TTracing.swift
@@ -150,6 +150,15 @@ public enum DP3TTracing {
         try instance.resetExposureDays()
     }
 
+    /// checks if infection status is resettable
+
+    public static var isInfectionStatusResettable: Bool {
+        guard instance != nil else {
+            fatalError("DP3TSDK not initialized call `initialize(with:delegate:)`")
+        }
+        return instance.isInfectionStatusResettable
+    }
+
     /// reset the infection status
 
     public static func resetInfectionStatus() throws {

--- a/Sources/DP3TSDK/Storage/Defaults.swift
+++ b/Sources/DP3TSDK/Storage/Defaults.swift
@@ -27,6 +27,8 @@ protocol DefaultStorage {
 
     var exposureDetectionDates: [Date] { get set }
 
+    var infectionStatusIsResettable: Bool { get set }
+
     func reset()
 }
 
@@ -52,6 +54,11 @@ class Default: DefaultStorage {
 
     @Persisted(userDefaultsKey: "org.dpppt.exposureDetectionDates", defaultValue: [])
     var exposureDetectionDates: [Date]
+
+    /// Is infection status resettable
+    /// on iOS > 13.7 we need to delay to disable of tracing until OutstandingPublishOperation is finished
+    @KeychainPersisted(key: "org.dpppt.infectionStatusIsResettable", defaultValue: true)
+    var infectionStatusIsResettable: Bool
 
     /// Parameters
     private func saveParameters(_ parameters: DP3TParameters) {
@@ -108,6 +115,7 @@ class Default: DefaultStorage {
         lastSync = nil
         didMarkAsInfected = false
         lastSyncTimestamps = [:]
+        infectionStatusIsResettable = true
     }
 }
 

--- a/Sources/DP3TSDK/Tracing/ExposureNotificationTracer.swift
+++ b/Sources/DP3TSDK/Tracing/ExposureNotificationTracer.swift
@@ -181,6 +181,10 @@ extension TrackingState {
             self = .inactive(error: .bluetoothTurnedOff)
         case .restricted:
             self = .inactive(error: .permissonError)
+        case .paused:
+            self = .stopped
+        case .unauthorized:
+            self = .inactive(error: .permissonError)
         @unknown default:
             fatalError()
         }

--- a/Tests/DP3TSDKTests/DP3TSDKTests.swift
+++ b/Tests/DP3TSDKTests/DP3TSDKTests.swift
@@ -93,7 +93,7 @@ class DP3TSDKTests: XCTestCase {
         try! sdk.startTracing { (err) in
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1.0)
+        wait(for: [exp], timeout: 2.0)
         XCTAssertEqual(tracer.state, TrackingState.active)
     }
 

--- a/Tests/DP3TSDKTests/DP3TSDKTests.swift
+++ b/Tests/DP3TSDKTests/DP3TSDKTests.swift
@@ -127,7 +127,7 @@ class DP3TSDKTests: XCTestCase {
         XCTAssertEqual(outstandingPublishStorage.get().count, 1)
 
         if #available(iOS 13.7, *) {
-            XCTAssert(defaults.infectionStatusIsResettable == false)
+            XCTAssertFalse(defaults.infectionStatusIsResettable)
         }
         XCTAssert(model != nil)
         XCTAssertEqual(model!.gaenKeys.count, defaults.parameters.crypto.numberOfKeysToSubmit)

--- a/Tests/DP3TSDKTests/DiagnosisKeysProviderTests.swift
+++ b/Tests/DP3TSDKTests/DiagnosisKeysProviderTests.swift
@@ -30,7 +30,7 @@ class DiagnosisKeysProviderTests: XCTestCase {
         manager.keys = [.initialize(rollingStartNumber: day.period)]
 
         let exp = expectation(description: "getDiagnosisKeys")
-        manager.getDiagnosisKeys(onsetDate: onset, appDesc: descriptor) { (result) in
+        manager.getDiagnosisKeys(onsetDate: onset, appDesc: descriptor, disableExposureNotificationAfterCompletion: false) { (result) in
             switch result {
             case .failure(_):
                 XCTFail()
@@ -48,7 +48,7 @@ class DiagnosisKeysProviderTests: XCTestCase {
         manager.keys = [.initialize(rollingStartNumber: day.period)]
 
         let exp = expectation(description: "getDiagnosisKeys")
-        manager.getDiagnosisKeys(onsetDate: onset, appDesc: descriptor) { (result) in
+        manager.getDiagnosisKeys(onsetDate: onset, appDesc: descriptor, disableExposureNotificationAfterCompletion: false) { (result) in
             switch result {
             case .failure(_):
                 XCTFail()
@@ -67,7 +67,7 @@ class DiagnosisKeysProviderTests: XCTestCase {
         manager.keys = [.initialize(rollingStartNumber: day.period)]
 
         let exp = expectation(description: "getDiagnosisKeys")
-        manager.getDiagnosisKeys(onsetDate: onset, appDesc: descriptor) { (result) in
+        manager.getDiagnosisKeys(onsetDate: onset, appDesc: descriptor, disableExposureNotificationAfterCompletion: false) { (result) in
             switch result {
             case .failure(_):
                 XCTFail()

--- a/Tests/DP3TSDKTests/Mocks/MockDefaults.swift
+++ b/Tests/DP3TSDKTests/Mocks/MockDefaults.swift
@@ -26,6 +26,8 @@ class MockDefaults: DefaultStorage {
 
     var didMarkAsInfected: Bool = false
 
+    var infectionStatusIsResettable: Bool = true
+
     func reset() {
         exposureDetectionDates = []
         lastSyncTimestamps = [:]
@@ -34,5 +36,6 @@ class MockDefaults: DefaultStorage {
         isFirstLaunch = false
         lastSync = nil
         didMarkAsInfected = false
+        infectionStatusIsResettable = false
     }
 }

--- a/Tests/DP3TSDKTests/Mocks/MockTracer.swift
+++ b/Tests/DP3TSDKTests/Mocks/MockTracer.swift
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+@testable import DP3TSDK
+import Foundation
+
+class MockTracer: Tracer {
+    var isAuthorized: Bool = true
+
+    var delegate: TracerDelegate?
+
+    var state: TrackingState = .active
+
+    var isEnabled = false
+
+    func setEnabled(_ enabled: Bool, completionHandler: ((Error?) -> Void)?) {
+        isEnabled = enabled
+        completionHandler?(nil)
+    }
+
+    func addInitialisationCallback(callback: @escaping () -> Void) {
+        callback()
+    }
+}

--- a/Tests/DP3TSDKTests/OutstandingPublishOperationTests.swift
+++ b/Tests/DP3TSDKTests/OutstandingPublishOperationTests.swift
@@ -112,7 +112,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 0)
         XCTAssertEqual(mockManager.fakeAccessedCount, 0)
         XCTAssertEqual(mockManager.realAccessedCount, 0)
-        XCTAssert(mockDefaults.infectionStatusIsResettable == false)
+        XCTAssertFalse(mockDefaults.infectionStatusIsResettable)
     }
 
     func testPublishBeforeMidnight(){
@@ -145,7 +145,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 0)
         XCTAssertEqual(mockManager.fakeAccessedCount, 0)
         XCTAssertEqual(mockManager.realAccessedCount, 0)
-        XCTAssert(mockDefaults.infectionStatusIsResettable == false)
+        XCTAssertFalse(mockDefaults.infectionStatusIsResettable)
     }
 
 
@@ -179,7 +179,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 1)
         XCTAssertEqual(mockManager.fakeAccessedCount, 0)
         XCTAssertEqual(mockManager.realAccessedCount, 1)
-        XCTAssert(mockDefaults.infectionStatusIsResettable == true)
+        XCTAssert(mockDefaults.infectionStatusIsResettable)
     }
 
 
@@ -210,7 +210,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 1)
         XCTAssertEqual(mockManager.fakeAccessedCount, 1)
         XCTAssertEqual(mockManager.realAccessedCount, 0)
-        XCTAssert(mockDefaults.infectionStatusIsResettable == false)
+        XCTAssertFalse(mockDefaults.infectionStatusIsResettable)
     }
 
     func testPublishingReal() {
@@ -249,7 +249,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 2)
         XCTAssertEqual(mockManager.fakeAccessedCount, 0)
         XCTAssertEqual(mockManager.realAccessedCount, 2)
-        XCTAssert(mockDefaults.infectionStatusIsResettable == true)
+        XCTAssert(mockDefaults.infectionStatusIsResettable)
     }
 
     func testPublishingDiagnosisKeyProviderError() {
@@ -278,7 +278,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 0)
         XCTAssertEqual(mockManager.fakeAccessedCount, 0)
         XCTAssertEqual(mockManager.realAccessedCount, 1)
-        XCTAssert(mockDefaults.infectionStatusIsResettable == true)
+        XCTAssert(mockDefaults.infectionStatusIsResettable)
     }
 
     func testPublishingExposeeServiceClientError() {
@@ -310,7 +310,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 1)
         XCTAssertEqual(mockManager.fakeAccessedCount, 1)
         XCTAssertEqual(mockManager.realAccessedCount, 0)
-        XCTAssert(mockDefaults.infectionStatusIsResettable == false)
+        XCTAssertFalse(mockDefaults.infectionStatusIsResettable)
     }
 
     static var formatter: DateFormatter = {

--- a/Tests/DP3TSDKTests/OutstandingPublishOperationTests.swift
+++ b/Tests/DP3TSDKTests/OutstandingPublishOperationTests.swift
@@ -37,7 +37,7 @@ private class MockManager: DiagnosisKeysProvider {
         }
     }
 
-    func getDiagnosisKeys(onsetDate _: Date?, appDesc _: ApplicationDescriptor, completionHandler: @escaping (Result<[CodableDiagnosisKey], DP3TTracingError>) -> Void) {
+    func getDiagnosisKeys(onsetDate _: Date?, appDesc _: ApplicationDescriptor, disableExposureNotificationAfterCompletion: Bool, completionHandler: @escaping (Result<[CodableDiagnosisKey], DP3TTracingError>) -> Void) {
         realAccessedCount += 1
         if let error = error {
             completionHandler(.failure(error))
@@ -95,11 +95,16 @@ final class OutstandingPublishOperationTests: XCTestCase {
 
         let service = ExposeeServiceClientMock()
 
+        let mockDefaults = MockDefaults()
+        mockDefaults.infectionStatusIsResettable = false
+
         let operationQueue = OperationQueue()
         let operationToTest = OutstandingPublishOperation(keyProvider: mockManager,
                                                           serviceClient: service,
                                                           storage: storage,
-                                                          runningInBackground: false)
+                                                          runningInBackground: false,
+                                                          defaults: mockDefaults,
+                                                          tracer: MockTracer())
 
         operationQueue.addOperations([operationToTest], waitUntilFinished: true)
 
@@ -107,6 +112,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 0)
         XCTAssertEqual(mockManager.fakeAccessedCount, 0)
         XCTAssertEqual(mockManager.realAccessedCount, 0)
+        XCTAssert(mockDefaults.infectionStatusIsResettable == false)
     }
 
     func testPublishBeforeMidnight(){
@@ -120,12 +126,17 @@ final class OutstandingPublishOperationTests: XCTestCase {
         storage.add(OutstandingPublish(authorizationHeader: "ABCD", dayToPublish: dateToPublish, fake: false))
 
         let service = ExposeeServiceClientMock()
+        let mockDefaults = MockDefaults()
+        mockDefaults.infectionStatusIsResettable = false
+
 
         let operationQueue = OperationQueue()
         let operationToTest = MockOutstandingPublishOperation(keyProvider: mockManager,
                                                           serviceClient: service,
                                                           storage: storage,
-                                                          runningInBackground: false)
+                                                          runningInBackground: false,
+                                                          defaults: mockDefaults,
+                                                          tracer: MockTracer())
         operationToTest.mockDate = dateToPublish.addingTimeInterval(22 * .hour + 30 * .minute)
 
         operationQueue.addOperations([operationToTest], waitUntilFinished: true)
@@ -134,6 +145,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 0)
         XCTAssertEqual(mockManager.fakeAccessedCount, 0)
         XCTAssertEqual(mockManager.realAccessedCount, 0)
+        XCTAssert(mockDefaults.infectionStatusIsResettable == false)
     }
 
 
@@ -149,12 +161,16 @@ final class OutstandingPublishOperationTests: XCTestCase {
         storage.add(OutstandingPublish(authorizationHeader: "ABCD", dayToPublish: dateToPublish, fake: false))
 
         let service = ExposeeServiceClientMock()
+        let mockDefaults = MockDefaults()
+        mockDefaults.infectionStatusIsResettable = false
 
         let operationQueue = OperationQueue()
         let operationToTest = MockOutstandingPublishOperation(keyProvider: mockManager,
                                                           serviceClient: service,
                                                           storage: storage,
-                                                          runningInBackground: false)
+                                                          runningInBackground: false,
+                                                          defaults: mockDefaults,
+                                                          tracer: MockTracer())
         operationToTest.mockDate = dateToPublish.addingTimeInterval(.day + 1)
 
         operationQueue.addOperations([operationToTest], waitUntilFinished: true)
@@ -163,6 +179,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 1)
         XCTAssertEqual(mockManager.fakeAccessedCount, 0)
         XCTAssertEqual(mockManager.realAccessedCount, 1)
+        XCTAssert(mockDefaults.infectionStatusIsResettable == true)
     }
 
 
@@ -176,12 +193,16 @@ final class OutstandingPublishOperationTests: XCTestCase {
         storage.add(OutstandingPublish(authorizationHeader: "ABCD", dayToPublish: Date(timeIntervalSinceNow: -86500), fake: true))
 
         let service = ExposeeServiceClientMock()
+        let mockDefaults = MockDefaults()
+        mockDefaults.infectionStatusIsResettable = false
 
         let operationQueue = OperationQueue()
         let operationToTest = OutstandingPublishOperation(keyProvider: mockManager,
                                                           serviceClient: service,
                                                           storage: storage,
-                                                          runningInBackground: false)
+                                                          runningInBackground: false,
+                                                          defaults: mockDefaults,
+                                                          tracer: MockTracer())
 
         operationQueue.addOperations([operationToTest], waitUntilFinished: true)
 
@@ -189,6 +210,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 1)
         XCTAssertEqual(mockManager.fakeAccessedCount, 1)
         XCTAssertEqual(mockManager.realAccessedCount, 0)
+        XCTAssert(mockDefaults.infectionStatusIsResettable == false)
     }
 
     func testPublishingReal() {
@@ -210,12 +232,16 @@ final class OutstandingPublishOperationTests: XCTestCase {
         storage.add(OutstandingPublish(authorizationHeader: "ABCD", dayToPublish: Date(timeIntervalSinceNow: 600), fake: false)) // In Future
 
         let service = ExposeeServiceClientMock()
+        let mockDefaults = MockDefaults()
+        mockDefaults.infectionStatusIsResettable = false
 
         let operationQueue = OperationQueue()
         let operationToTest = OutstandingPublishOperation(keyProvider: mockManager,
                                                           serviceClient: service,
                                                           storage: storage,
-                                                          runningInBackground: false)
+                                                          runningInBackground: false,
+                                                          defaults: mockDefaults,
+                                                          tracer: MockTracer())
 
         operationQueue.addOperations([operationToTest], waitUntilFinished: true)
 
@@ -223,6 +249,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 2)
         XCTAssertEqual(mockManager.fakeAccessedCount, 0)
         XCTAssertEqual(mockManager.realAccessedCount, 2)
+        XCTAssert(mockDefaults.infectionStatusIsResettable == true)
     }
 
     func testPublishingDiagnosisKeyProviderError() {
@@ -234,12 +261,16 @@ final class OutstandingPublishOperationTests: XCTestCase {
         storage.add(OutstandingPublish(authorizationHeader: "ABCD", dayToPublish: Date(timeIntervalSinceNow: -88800), fake: false))
 
         let service = ExposeeServiceClientMock()
+        let mockDefaults = MockDefaults()
+        mockDefaults.infectionStatusIsResettable = false
 
         let operationQueue = OperationQueue()
         let operationToTest = OutstandingPublishOperation(keyProvider: mockManager,
                                                           serviceClient: service,
                                                           storage: storage,
-                                                          runningInBackground: false)
+                                                          runningInBackground: false,
+                                                          defaults: mockDefaults,
+                                                          tracer: MockTracer())
 
         operationQueue.addOperations([operationToTest], waitUntilFinished: true)
 
@@ -247,6 +278,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 0)
         XCTAssertEqual(mockManager.fakeAccessedCount, 0)
         XCTAssertEqual(mockManager.realAccessedCount, 1)
+        XCTAssert(mockDefaults.infectionStatusIsResettable == true)
     }
 
     func testPublishingExposeeServiceClientError() {
@@ -261,12 +293,16 @@ final class OutstandingPublishOperationTests: XCTestCase {
 
         let service = ExposeeServiceClientMock()
         service.error = DP3TNetworkingError.couldNotEncodeBody
+        let mockDefaults = MockDefaults()
+        mockDefaults.infectionStatusIsResettable = false
 
         let operationQueue = OperationQueue()
         let operationToTest = OutstandingPublishOperation(keyProvider: mockManager,
                                                           serviceClient: service,
                                                           storage: storage,
-                                                          runningInBackground: false)
+                                                          runningInBackground: false,
+                                                          defaults: mockDefaults,
+                                                          tracer: MockTracer())
 
         operationQueue.addOperations([operationToTest], waitUntilFinished: true)
 
@@ -274,6 +310,7 @@ final class OutstandingPublishOperationTests: XCTestCase {
         XCTAssertEqual(service.addedExposeeListCount, 1)
         XCTAssertEqual(mockManager.fakeAccessedCount, 1)
         XCTAssertEqual(mockManager.realAccessedCount, 0)
+        XCTAssert(mockDefaults.infectionStatusIsResettable == false)
     }
 
     static var formatter: DateFormatter = {


### PR DESCRIPTION
This PR fixes an issue regarding the current day key export on devices with iOS greater than 13.7.
Previously we were able to enable the EN framework, export the key, and then disable it again. Starting with iOS 13.7 this is not possible anymore if the application is in the background. 
Therefore we have to keep the EN framework enabled until we export the current day key. After we were able to export the key we disable the EN framework again.

As a result of that a user that publishes their keys won't be able to delete its infection status until we tried to export the current day key. This can be checked by the app with the bool DP3TTracing.isInfectionStatusResettable.
