### PR TITLE
Remove 'Bearer' prefix from auth token.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for DP3T-SDK iOS
 
+## Version 1.2.2 ()
+- 'Bearer' is not added as prefix to auth key if using HTTPAuthorizationBearer auth method. 
+
 ## Version 1.2.1 (31.08.2020)
 - ensures that backgroundtask keeps running until outstandingPublishOperation is finished
 

--- a/Sources/DP3TSDK/Networking/ExposeeServiceClient.swift
+++ b/Sources/DP3TSDK/Networking/ExposeeServiceClient.swift
@@ -242,7 +242,7 @@ class ExposeeServiceClient: ExposeeServiceClientProtocol {
         request.addValue(String(payload.count), forHTTPHeaderField: "Content-Length")
         request.addValue(userAgent, forHTTPHeaderField: "User-Agent")
         if case let ExposeeAuthMethod.HTTPAuthorizationBearer(token: token) = authentication {
-            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            request.addValue(token, forHTTPHeaderField: "Authorization")
         }
         request.httpBody = payload
 


### PR DESCRIPTION
The DP3T iOS SDK modified the auth key of HTTPAuthorizationBearer auth method with a 'Bearer' prefix.
This was not in sync with Android SDK implementation.
This PR removes this prefix.

Changelog was modified, because this change may potentially break existing projects if backend is configured to expect this prefix.