### PR TITLE
Expose enabled state

### DIFF
--- a/SampleApp/DP3TSampleApp/ControlViewController.swift
+++ b/SampleApp/DP3TSampleApp/ControlViewController.swift
@@ -465,6 +465,17 @@ class ControlViewController: UIViewController {
             segmentedControl.selectedSegmentIndex = 0
             startReceivingButton.isEnabled = false
             startAdvertisingButton.isEnabled = false
+        case .inactive(let error):
+            switch error {
+            case .bluetoothTurnedOff(let enabled) where enabled == true:
+                segmentedControl.selectedSegmentIndex = 0
+                startReceivingButton.isEnabled = false
+                startAdvertisingButton.isEnabled = false
+            default:
+                segmentedControl.selectedSegmentIndex = 1
+                startReceivingButton.isEnabled = true
+                startAdvertisingButton.isEnabled = true
+            }
         default:
             segmentedControl.selectedSegmentIndex = 1
             startReceivingButton.isEnabled = true
@@ -526,7 +537,7 @@ private extension TrackingState {
         case .active:
             return "active"
         case let .inactive(error):
-            return "inactive \(error.localizedDescription)"
+            return "inactive \(error.description)"
         case .stopped:
             return "stopped"
         }
@@ -536,8 +547,8 @@ private extension TrackingState {
 extension DP3TTracingError {
     var description: String {
         switch self {
-        case .bluetoothTurnedOff:
-            return "bluetoothTurnedOff"
+        case .bluetoothTurnedOff(let enabled):
+            return "bluetoothTurnedOff EN:\(enabled ? "enabled" : "disabled")"
         case let .caseSynchronizationError(errors: errors):
             return "caseSynchronizationError \(errors.map { $0.localizedDescription })"
         case let .databaseError(error: error):

--- a/SampleApp/DP3TSampleApp/ControlViewController.swift
+++ b/SampleApp/DP3TSampleApp/ControlViewController.swift
@@ -551,8 +551,6 @@ extension DP3TTracingError {
             return "bluetoothTurnedOff EN:\(enabled ? "enabled" : "disabled")"
         case let .caseSynchronizationError(errors: errors):
             return "caseSynchronizationError \(errors.map { $0.localizedDescription })"
-        case let .databaseError(error: error):
-            return "databaseError \(error?.localizedDescription ?? "nil")"
         case let .networkingError(error: error):
             return "networkingError \(error.localizedDescription)"
         case .permissonError:

--- a/SampleApp/DP3TSampleApp/KeysViewController.swift
+++ b/SampleApp/DP3TSampleApp/KeysViewController.swift
@@ -52,13 +52,6 @@ class KeysViewController: UIViewController {
 
     private let nameRegex = try? NSRegularExpression(pattern: "key_export_experiment_([a-zA-Z0-9]+)_(.+)", options: .caseInsensitive)
 
-    struct RowData {
-        let isSectionGroupHeader: Bool
-        let title: String
-        let zips: [NetworkingHelper.DebugZips]
-        var result: String?
-    }
-
     init() {
         super.init(nibName: nil, bundle: nil)
         title = "Keys"

--- a/SampleApp/DP3TSampleApp/KeysViewController.swift
+++ b/SampleApp/DP3TSampleApp/KeysViewController.swift
@@ -52,6 +52,13 @@ class KeysViewController: UIViewController {
 
     private let nameRegex = try? NSRegularExpression(pattern: "key_export_experiment_([a-zA-Z0-9]+)_(.+)", options: .caseInsensitive)
 
+    struct RowData {
+        let isSectionGroupHeader: Bool
+        let title: String
+        let zips: [NetworkingHelper.DebugZips]
+        var result: String?
+    }
+
     init() {
         super.init(nibName: nil, bundle: nil)
         title = "Keys"

--- a/Sources/DP3TSDK/DP3TError.swift
+++ b/Sources/DP3TSDK/DP3TError.swift
@@ -21,11 +21,7 @@ public enum DP3TTracingError: Error {
     /// The operation was cancelled
     case cancelled
 
-    /// Database Error
-    case databaseError(error: Error?)
-
     /// Expsure notification framework error
-
     case exposureNotificationError(error: Error)
 
     /// Bluetooth device turned off

--- a/Sources/DP3TSDK/DP3TError.swift
+++ b/Sources/DP3TSDK/DP3TError.swift
@@ -29,7 +29,8 @@ public enum DP3TTracingError: Error {
     case exposureNotificationError(error: Error)
 
     /// Bluetooth device turned off
-    case bluetoothTurnedOff
+    /// The associated boolean indicates if the ENFramework would be enabled
+    case bluetoothTurnedOff(enabled: Bool)
 
     /// Bluetooth permission error
     case permissonError

--- a/Sources/DP3TSDK/DP3TSDK.swift
+++ b/Sources/DP3TSDK/DP3TSDK.swift
@@ -192,7 +192,7 @@ class DP3TSDK {
             var storedResult: SyncResult?
 
             // Skip sync when tracing is not active
-            if self.state.trackingState != .active {
+            if false, self.state.trackingState != .active {
                 self.log.error("Skip sync when tracking is not active")
                 storedResult = .skipped
             } else {

--- a/Sources/DP3TSDK/Tracing/ExposureNotificationTracer.swift
+++ b/Sources/DP3TSDK/Tracing/ExposureNotificationTracer.swift
@@ -178,7 +178,7 @@ extension TrackingState {
         case .unknown, .disabled:
             self = .stopped
         case .bluetoothOff:
-            self = .inactive(error: .bluetoothTurnedOff)
+            self = .inactive(error: .bluetoothTurnedOff(enabled: enabled))
         case .restricted:
             self = .inactive(error: .permissonError)
         case .paused:

--- a/Tests/DP3TSDKTests/DP3TSDKTests.swift
+++ b/Tests/DP3TSDKTests/DP3TSDKTests.swift
@@ -84,7 +84,7 @@ class DP3TSDKTests: XCTestCase {
             }
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: 1.0)
     }
 
     func testCallEnable(){
@@ -114,14 +114,14 @@ class DP3TSDKTests: XCTestCase {
             }
             stateexp.fulfill()
         }
-        wait(for: [stateexp], timeout: 0.1)
+        wait(for: [stateexp], timeout: 1.0)
 
         let exp = expectation(description: "infected")
         keyProvider.keys = [ .init(keyData: Data(count: 16), rollingPeriod: 144, rollingStartNumber: DayDate().period, transmissionRiskLevel: 0, fake: 0) ]
         sdk.iWasExposed(onset: .init(timeIntervalSinceNow: -.day), authentication: .none) { (result) in
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: 1.0)
         let model = service.exposeeListModel
 
         XCTAssertEqual(outstandingPublishStorage.get().count, 1)
@@ -165,7 +165,7 @@ class DP3TSDKTests: XCTestCase {
             }
             stateExpAfter.fulfill()
         }
-        wait(for: [stateExpAfter], timeout: 0.1)
+        wait(for: [stateExpAfter], timeout: 1.0)
 
 
         XCTAssertThrowsError(try sdk.startTracing())
@@ -177,7 +177,7 @@ class DP3TSDKTests: XCTestCase {
         sdk.sync(runningInBackground: false) { (result) in
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: 1.0)
     }
 
     func testSyncCompleteAfterInit(){
@@ -186,7 +186,7 @@ class DP3TSDKTests: XCTestCase {
             exp.fulfill()
         }
         manager.completeActivation()
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: 1.0)
     }
 
     func testSyncWhenActive(){
@@ -235,7 +235,7 @@ class DP3TSDKTests: XCTestCase {
             }
             expStatus.fulfill()
         }
-        wait(for: [expStatus], timeout: 0.1)
+        wait(for: [expStatus], timeout: 1.0)
 
 
         // app comes again in foreground
@@ -261,7 +261,7 @@ class DP3TSDKTests: XCTestCase {
             }
             expStatusAfter.fulfill()
         }
-        wait(for: [expStatusAfter], timeout: 0.1)
+        wait(for: [expStatusAfter], timeout: 1.0)
     }
 
     func testEnableAfterEnableFailure(){

--- a/Tests/DP3TSDKTests/ExposureNotificationTracerTests.swift
+++ b/Tests/DP3TSDKTests/ExposureNotificationTracerTests.swift
@@ -82,7 +82,7 @@ class ExposureNotificationTracerTests: XCTestCase {
 
         let ex = expectation(description: "init")
         tracer.addInitialisationCallback {
-            XCTAssertEqual(self.tracer.state, TrackingState.inactive(error: .bluetoothTurnedOff))
+            XCTAssertEqual(self.tracer.state, TrackingState.inactive(error: .bluetoothTurnedOff(enabled: false)))
 
             ex.fulfill()
         }

--- a/Tests/DP3TSDKTests/KnownCasesSynchronizerTests.swift
+++ b/Tests/DP3TSDKTests/KnownCasesSynchronizerTests.swift
@@ -164,7 +164,7 @@ final class KnownCasesSynchronizerTests: XCTestCase {
     func testDontStoreLastSyncMatchingError() {
         let matcher = MockMatcher()
         let service = MockService()
-        matcher.error = DP3TTracingError.bluetoothTurnedOff
+        matcher.error = DP3TTracingError.bluetoothTurnedOff(enabled: false)
         let defaults = MockDefaults()
         let sync = KnownCasesSynchronizer(matcher: matcher,
                                           service: service,
@@ -172,7 +172,7 @@ final class KnownCasesSynchronizerTests: XCTestCase {
                                           descriptor: .init(appId: "ch.dpppt", bucketBaseUrl: URL(string: "http://www.google.de")!, reportBaseUrl: URL(string: "http://www.google.de")!))
         let expecation = expectation(description: "syncExpectation")
         sync.sync(now: .init(timeIntervalSinceNow: .hour)) { res in
-            XCTAssertEqual(res, SyncResult.failure(.bluetoothTurnedOff))
+            XCTAssertEqual(res, SyncResult.failure(.bluetoothTurnedOff(enabled: false)))
             expecation.fulfill()
         }
         waitForExpectations(timeout: 1)


### PR DESCRIPTION
- exposes enabled boolean to the app even if the tracing is inactive due to Bluetooth turned off
- removes the unused error (databaseError)
- increases timeout to make unit tests more stable