### PR TITLE
fixes status callback while initialisation

### DIFF
--- a/Sources/DP3TSDK/DP3TSDK.swift
+++ b/Sources/DP3TSDK/DP3TSDK.swift
@@ -234,9 +234,18 @@ class DP3TSDK {
 
     /// get the current status of the SDK
     /// - Parameter callback: callback
-    func status(callback: (Result<TracingState, DP3TTracingError>) -> Void) {
+    func status(callback: @escaping (Result<TracingState, DP3TTracingError>) -> Void) {
         log.trace()
-        callback(.success(state))
+        if self.state.trackingState == .initialization {
+            tracer.addInitialisationCallback { [weak self] in
+                guard let self = self else { return }
+                DispatchQueue.main.async {
+                    callback(.success(self.state))
+                }
+            }
+        } else  {
+            callback(.success(state))
+        }
     }
 
     /// tell the SDK that the user was exposed

--- a/Sources/DP3TSDK/DP3TTracing.swift
+++ b/Sources/DP3TSDK/DP3TTracing.swift
@@ -114,7 +114,7 @@ public enum DP3TTracing {
     /// get the current status of the SDK
     /// - Parameter callback: callback
 
-    public static func status(callback: (Result<TracingState, DP3TTracingError>) -> Void) {
+    public static func status(callback: @escaping (Result<TracingState, DP3TTracingError>) -> Void) {
         guard let instance = instance else {
             fatalError("DP3TSDK not initialized call `initialize(with:delegate:)`")
         }

--- a/Tests/DP3TSDKTests/DP3TSDKTests.swift
+++ b/Tests/DP3TSDKTests/DP3TSDKTests.swift
@@ -73,20 +73,6 @@ class DP3TSDKTests: XCTestCase {
                           defaults: defaults)
     }
 
-    func testInitialStatus(){
-        let exp = expectation(description: "status")
-        sdk.status { (result) in
-            switch result {
-            case .failure(_):
-                XCTFail()
-            case let .success(state):
-                XCTAssert(state.trackingState == .initialization)
-            }
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 0.1)
-    }
-
     func testCallEnable(){
         manager.completeActivation()
         let exp = expectation(description: "enable")
@@ -100,6 +86,7 @@ class DP3TSDKTests: XCTestCase {
     func testInfected(){
 
         let stateexp = expectation(description: "stateBefore")
+        manager.completeActivation()
         sdk.status { (result) in
             switch result {
             case .failure(_):
@@ -165,6 +152,7 @@ class DP3TSDKTests: XCTestCase {
             }
             stateExpAfter.fulfill()
         }
+        manager.completeActivation()
         wait(for: [stateExpAfter], timeout: 0.1)
 
 


### PR DESCRIPTION
- delay status callback until tracer is completely initialized
- this prevents apps from displaying pre-initialized state of the SDK