### PR TITLE
Introduce new tracing error (.authorizationUnknown) 

### DIFF
--- a/SampleApp/DP3TSampleApp/ControlViewController.swift
+++ b/SampleApp/DP3TSampleApp/ControlViewController.swift
@@ -545,7 +545,9 @@ extension DP3TTracingError {
         case let .networkingError(error: error):
             return "networkingError \(error.localizedDescription)"
         case .permissonError:
-            return "networkingError"
+            return "permissionError"
+        case .authorizationUnknown:
+            return "authorizationUnknown"
         case .userAlreadyMarkedAsInfected:
             return "userAlreadyMarkedAsInfected"
         case let .exposureNotificationError(error: error):

--- a/Sources/DP3TSDK/DP3TError.swift
+++ b/Sources/DP3TSDK/DP3TError.swift
@@ -31,7 +31,10 @@ public enum DP3TTracingError: Error {
     /// Bluetooth device turned off
     case bluetoothTurnedOff
 
-    /// Bluetooth permission error
+    /// User has not been prompted for authorization yet (using startTracing() will prompt the user).
+    case authorizationUnknown
+
+    /// The user either denied authorization or region is not active
     case permissonError
 
     /// The user was marked as infected

--- a/Sources/DP3TSDK/Tracing/ExposureNotificationTracer.swift
+++ b/Sources/DP3TSDK/Tracing/ExposureNotificationTracer.swift
@@ -164,10 +164,23 @@ class ExposureNotificationTracer: Tracer {
 
 extension TrackingState {
     init(state: ENStatus, authorizationStatus: ENAuthorizationStatus, enabled: Bool) {
-        guard authorizationStatus == .authorized else {
+
+        // Check authorization status first
+        switch authorizationStatus {
+        case .authorized:
+            // Continue with state
+            break
+        case .unknown:
+            self = .inactive(error: .authorizationUnknown)
+            return
+        case .notAuthorized, .restricted:
             self = .inactive(error: .permissonError)
             return
+        @unknown default:
+            fatalError()
         }
+
+        // Continue with state
         switch state {
         case .active:
             if enabled {


### PR DESCRIPTION
This allows to distinguish whether user has been prompted yet. Until now, it was not possible to differentiate whether a user denied the permission or was not prompted yet. This is also the case after a user taps on "Turn Off Exposure Notifications" in the iOS settings (which removes the permission and resets the authorization state back to unknown).