### PR TITLE
Refactor authentication methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for DP3T-SDK iOS
 
+##
+- 'Bearer' is not added as a prefix to auth key if using HTTPAuthorizationHeader auth method. 
+- HTTPAuthorizationBearer auth method is deprecated
+
 ## Version 1.3.0 (29.09.2020)
 - Improve last day TEK export handling for iOS > 13.7 (must not disable EN until the following day)
 - Introduce new tracing error (.authorizationUnknown) to be able to handle users that did not grant (or revoked authorization by disabling exposure notifications in the iOS settings).

--- a/Sources/DP3TSDK/Models/ExposeeAuthMethod.swift
+++ b/Sources/DP3TSDK/Models/ExposeeAuthMethod.swift
@@ -14,8 +14,9 @@ import Foundation
 public enum ExposeeAuthMethod {
     /// No authentication
     case none
-    /// Send the authentication as part the JSON payload
-    case JSONPayload(token: String)
     /// Send the authentication as a HTTP Header Authentication bearer token
+    @available(*, deprecated, renamed: "HTTPAuthorizationHeader")
     case HTTPAuthorizationBearer(token: String)
+    /// Send the authentication as a HTTP Header
+    case HTTPAuthorizationHeader(header: String, value: String)
 }

--- a/Sources/DP3TSDK/Networking/ExposeeServiceClient.swift
+++ b/Sources/DP3TSDK/Networking/ExposeeServiceClient.swift
@@ -241,9 +241,16 @@ class ExposeeServiceClient: ExposeeServiceClientProtocol {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue(String(payload.count), forHTTPHeaderField: "Content-Length")
         request.addValue(userAgent, forHTTPHeaderField: "User-Agent")
-        if case let ExposeeAuthMethod.HTTPAuthorizationBearer(token: token) = authentication {
+
+        switch authentication {
+        case .none:
+            break
+        case let .HTTPAuthorizationHeader(header: header, value: value):
+            request.addValue(value, forHTTPHeaderField: header)
+        case let .HTTPAuthorizationBearer(token: token):
             request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
+
         request.httpBody = payload
 
         let task = urlSession.dataTask(with: request, completionHandler: { data, response, error in


### PR DESCRIPTION
- removed JSONPayload since this was never implemented
- deprecates HTTPAuthorizationBearer
- adds HTTPAuthorizationHeader which gives the app more control