### PR TITLE
Adds more logs to ExposureNotificationMatcher

### DIFF
--- a/Sources/DP3TSDK/Matching/ExposureNotificationMatcher.swift
+++ b/Sources/DP3TSDK/Matching/ExposureNotificationMatcher.swift
@@ -77,7 +77,9 @@ class ExposureNotificationMatcher: Matcher {
                 logger.error("ENManager.getExposureWindows failed error: %{public}@", error.localizedDescription)
                 throw DP3TTracingError.exposureNotificationError(error: error)
             case let .success(value):
-                logger.log("received windows: %{public}@", value.description)
+                for window in value {
+                    logger.log("received window for day: %{public}@ with scanInstances: %{public}@", window.date.description, window.scanInstances)
+                }
                 windows = value
             }
 
@@ -112,10 +114,11 @@ class ExposureNotificationMatcher: Matcher {
             let attenuationValues = windows.attenuationValues(lowerThreshold: parameters.lowerThreshold,
                                                               higherThreshold: parameters.higherThreshold)
 
-            logger.log("day: %{public}@ lowerBucket: %{public}d upperBucket: %{public}d (lowerThreshold: %{public}d, higherThreshold: %{public}d)",
+            logger.log("day: %{public}@ lowerBucket: %{public}d upperBucket: %{public}d disregarded: %{public}d (lowerThreshold: %{public}d, higherThreshold: %{public}d)",
                        day.description,
                        attenuationValues.lowerBucket,
                        attenuationValues.higherBucket,
+                       attenuationValues.disregarded,
                        parameters.lowerThreshold,
                        parameters.higherThreshold)
 

--- a/Sources/DP3TSDK/Matching/ExposureWindow.swift
+++ b/Sources/DP3TSDK/Matching/ExposureWindow.swift
@@ -25,6 +25,7 @@ extension Array where Element: ENExposureWindow {
 struct AttenuationValues {
     let lowerBucket: Int
     let higherBucket: Int
+    let disregarded: Int
 }
 
 extension AttenuationValues {
@@ -67,6 +68,7 @@ extension Array where Element == ENExposureWindow {
     /// - Returns: the 2 buckets
     func attenuationValues(lowerThreshold: Int, higherThreshold: Int) -> AttenuationValues {
         return AttenuationValues(lowerBucket:  getSeconds(above: 0,              below: lowerThreshold),
-                                 higherBucket: getSeconds(above: lowerThreshold, below: higherThreshold))
+                                 higherBucket: getSeconds(above: lowerThreshold, below: higherThreshold),
+                                 disregarded:  getSeconds(above: higherThreshold, below: Int.max))
     }
 }

--- a/Tests/DP3TSDKTests/AttenuationValuesTests.swift
+++ b/Tests/DP3TSDKTests/AttenuationValuesTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 class AttenuationsValuesTests: XCTestCase {
     func testMatching() {
-        let attenuationValues = AttenuationValues(lowerBucket: 120, higherBucket: 120)
+        let attenuationValues = AttenuationValues(lowerBucket: 120, higherBucket: 120, disregarded: 0)
 
         XCTAssert(attenuationValues.matches(factorLow: 0, factorHigh: 1, triggerThreshold: 2))
         XCTAssert(attenuationValues.matches(factorLow: 1, factorHigh: 0, triggerThreshold: 2))
@@ -24,7 +24,7 @@ class AttenuationsValuesTests: XCTestCase {
     }
 
     func testRoundingMinutesUp(){
-        let attenuationValues = AttenuationValues(lowerBucket: 59, higherBucket: 0)
+        let attenuationValues = AttenuationValues(lowerBucket: 59, higherBucket: 0, disregarded: 0)
         XCTAssert(attenuationValues.matches(factorLow: 1, factorHigh: 0, triggerThreshold: 1))
     }
 }


### PR DESCRIPTION
- log disregarded attenuation seconds (above higherThreshold)
- log scanInstances along with ENExposureWindows