### PR TITLE
Expose oldest keydate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for DP3T-SDK iOS
 
+## next version
+- expose oldest shared keydate when calling iWasExposed
+
 ## Version 2.2.0 (25.03.2021)
 - Add support for international key exchange with parameter 'federationGateway'
 

--- a/Sources/DP3TSDK/DP3TSDK.swift
+++ b/Sources/DP3TSDK/DP3TSDK.swift
@@ -318,7 +318,7 @@ class DP3TSDK {
                                 self.tracer.setEnabled(false, completionHandler: nil)
                             }
 
-                            callback(.success((.init(oldestKeyDate: oldestNonFakeKeyDate))))
+                            callback(.success(.init(oldestKeyDate: oldestNonFakeKeyDate)))
                         case let .failure(error):
                             callback(.failure(.networkingError(error: error)))
                         }

--- a/Sources/DP3TSDK/DP3TSDK.swift
+++ b/Sources/DP3TSDK/DP3TSDK.swift
@@ -246,7 +246,7 @@ class DP3TSDK {
     func iWasExposed(onset: Date,
                      authentication: ExposeeAuthMethod,
                      isFakeRequest: Bool = false,
-                     callback: @escaping (Result<Void, DP3TTracingError>) -> Void) {
+                     callback: @escaping (Result<DP3TTracing.IWasExposedResult, DP3TTracingError>) -> Void) {
         log.trace()
         if !isFakeRequest,
             case .infected = state.infectionStatus {
@@ -299,6 +299,11 @@ class DP3TSDK {
                     withFederationGateway = nil
                 }
 
+                let oldestNonFakeKeyDate = mutableKeys
+                    .filter { $0.fake == 0 }
+                    .map(\.date)
+                    .min()
+
                 let model = ExposeeListModel(gaenKeys: mutableKeys,
                                              withFederationGateway: withFederationGateway,
                                              fake: isFakeRequest)
@@ -313,7 +318,7 @@ class DP3TSDK {
                                 self.tracer.setEnabled(false, completionHandler: nil)
                             }
 
-                            callback(.success(()))
+                            callback(.success((.init(oldestKeyDate: oldestNonFakeKeyDate))))
                         case let .failure(error):
                             callback(.failure(.networkingError(error: error)))
                         }

--- a/Sources/DP3TSDK/DP3TSDK.swift
+++ b/Sources/DP3TSDK/DP3TSDK.swift
@@ -299,10 +299,10 @@ class DP3TSDK {
                     withFederationGateway = nil
                 }
 
-                let oldestNonFakeKeyDate = mutableKeys
-                    .filter { $0.fake == 0 }
-                    .map(\.date)
-                    .min()
+                var oldestNonFakeKeyDate: Date? = nil
+                if !isFakeRequest {
+                    oldestNonFakeKeyDate = Date(timeIntervalSince1970: Double(oldestRollingStartNumber) *  10 * .minute)
+                }
 
                 let model = ExposeeListModel(gaenKeys: mutableKeys,
                                              withFederationGateway: withFederationGateway,

--- a/Sources/DP3TSDK/DP3TTracing.swift
+++ b/Sources/DP3TSDK/DP3TTracing.swift
@@ -135,6 +135,11 @@ public enum DP3TTracing {
         return instance.status
     }
 
+
+    public struct IWasExposedResult {
+        public let oldestKeyDate: Date?
+    }
+    
     /// tell the SDK that the user was exposed
     /// - Parameters:
     ///   - onset: Start date of the exposure
@@ -145,7 +150,7 @@ public enum DP3TTracing {
     public static func iWasExposed(onset: Date,
                                    authentication: ExposeeAuthMethod,
                                    isFakeRequest: Bool = false,
-                                   callback: @escaping (Result<Void, DP3TTracingError>) -> Void) {
+                                   callback: @escaping (Result<IWasExposedResult, DP3TTracingError>) -> Void) {
         instancePrecondition()
         instance.iWasExposed(onset: onset,
                              authentication: authentication,

--- a/Sources/DP3TSDK/Models/ExposeeListModel.swift
+++ b/Sources/DP3TSDK/Models/ExposeeListModel.swift
@@ -18,6 +18,12 @@ struct CodableDiagnosisKey: Codable, Equatable {
     let fake: UInt8
 }
 
+extension CodableDiagnosisKey {
+    var date: Date {
+        Date(timeIntervalSince1970: TimeInterval(rollingStartNumber) * TimeInterval.minute * 10)
+    }
+}
+
 /// Model of the exposed person
 struct ExposeeListModel: Encodable {
     /// Diagnosis keys

--- a/Sources/DP3TSDK/Networking/ExposeeServiceClient.swift
+++ b/Sources/DP3TSDK/Networking/ExposeeServiceClient.swift
@@ -54,7 +54,7 @@ class ExposeeServiceClient: ExposeeServiceClientProtocol {
 
     private let jwtVerifier: DP3TJWTVerifier?
 
-    var federationGateway: FederationGateway
+    internal var federationGateway: FederationGateway
 
     private let log = Logger(ExposeeServiceClient.self, category: "exposeeServiceClient")
 

--- a/Tests/DP3TSDKTests/DP3TSDKTests.swift
+++ b/Tests/DP3TSDKTests/DP3TSDKTests.swift
@@ -26,6 +26,7 @@ private class MockKeyProvider: DiagnosisKeysProvider {
 }
 
 
+@available(iOS 12.5, *)
 class DP3TSDKTests: XCTestCase {
 
     fileprivate var keychain: MockKeychain!

--- a/Tests/DP3TSDKTests/DiagnosisKeysProviderTests.swift
+++ b/Tests/DP3TSDKTests/DiagnosisKeysProviderTests.swift
@@ -13,6 +13,7 @@ import Foundation
 import XCTest
 import ExposureNotification
 
+@available(iOS 12.5, *)
 class DiagnosisKeysProviderTests: XCTestCase {
 
     var manager: MockENManager!
@@ -81,6 +82,7 @@ class DiagnosisKeysProviderTests: XCTestCase {
     
 }
 
+@available(iOS 12.5, *)
 extension ENTemporaryExposureKey {
     static func initialize(data: Data = Data(capacity: 16),
                            rollingPeriod: ENIntervalNumber = UInt32(TimeInterval.day / (.minute * 10)),

--- a/Tests/DP3TSDKTests/ExposureNotificationMatcherTests.swift
+++ b/Tests/DP3TSDKTests/ExposureNotificationMatcherTests.swift
@@ -15,6 +15,7 @@ import Foundation
 import XCTest
 import ZIPFoundation
 
+@available(iOS 12.5, *)
 final class ExposureNotificationMatcherTests: XCTestCase {
     var keychain = MockKeychain()
 

--- a/Tests/DP3TSDKTests/ExposureNotificationTracerTests.swift
+++ b/Tests/DP3TSDKTests/ExposureNotificationTracerTests.swift
@@ -11,6 +11,7 @@
 @testable import DP3TSDK
 import XCTest
 
+@available(iOS 12.5, *)
 class ExposureNotificationTracerTests: XCTestCase {
 
     var manager: MockENManager!

--- a/Tests/DP3TSDKTests/ExposureWindowTests.swift
+++ b/Tests/DP3TSDKTests/ExposureWindowTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import ExposureNotification
 
 
+@available(iOS 12.5, *)
 class ExposureWindowTests: XCTestCase {
     func testDayGroupingSingle(){
         var windows: [MockWindow] = []

--- a/Tests/DP3TSDKTests/Mocks/MockENManager.swift
+++ b/Tests/DP3TSDKTests/Mocks/MockENManager.swift
@@ -12,6 +12,7 @@
 import Foundation
 import ExposureNotification
 
+@available(iOS 12.5, *)
 class MockENManager: ENManager {
     var activateCallbacks: [ENErrorHandler] = []
 
@@ -108,6 +109,7 @@ class MockENManager: ENManager {
     }
 }
 
+@available(iOS 12.5, *)
 class MockSummary: ENExposureDetectionSummary {
     override var attenuationDurations: [NSNumber] {
         get {

--- a/Tests/DP3TSDKTests/Mocks/MockScanInstance.swift
+++ b/Tests/DP3TSDKTests/Mocks/MockScanInstance.swift
@@ -11,6 +11,7 @@
 import Foundation
 import ExposureNotification
 
+@available(iOS 12.5, *)
 class MockScanInstance: ENScanInstance {
 
     private var internalTypicalAttenuation: ENAttenuation

--- a/Tests/DP3TSDKTests/Mocks/MockWindow.swift
+++ b/Tests/DP3TSDKTests/Mocks/MockWindow.swift
@@ -11,6 +11,7 @@
 import Foundation
 import ExposureNotification
 
+@available(iOS 12.5, *)
 class MockWindow: ENExposureWindow {
     private var internalDate: Date
     private var internalScanInstances: [ENScanInstance]


### PR DESCRIPTION
Expose oldest shared key date when calling iWasExposed. This allows the app to display from where on keys have been shared.