### PR TITLE
Adds method to request user consent independent from sending the keys to the backend when marking user as exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for DP3T-SDK iOS
 
+## next version
+- adds methods which allows to seperatly  ask for user consent from sending the keys to the backend (DP3TTracing.requestTEKPermission and DP3TTracing.sendTEKs)
+- fixes retain cycle
+
 ## Version 2.3.0 (30.04.2021)
 - expose oldest shared keydate when calling iWasExposed
 

--- a/Sources/DP3TSDK/DP3TTracing.swift
+++ b/Sources/DP3TSDK/DP3TTracing.swift
@@ -139,8 +139,34 @@ public enum DP3TTracing {
     public struct IWasExposedResult {
         public let oldestKeyDate: Date?
     }
+
+    /// Request the user permission to obtain all TEK's
+    /// This results with a IWasExposedState object which later can be used to transmit the filtered TEK's to the backend by calling sendTEKs
+    /// - Parameter callback: a handler which receives the state object or an error
+    @available(iOS 12.5, *)
+    public static func requestTEKPermission(callback: @escaping (Result<IWasExposedState, DP3TTracingError>) -> Void) {
+        instancePrecondition()
+        instance.requestTEKPermission(callback: callback)
+    }
+
+    /// Send the obtained keys to the backend. First a valid state has to be obtained by calling requestTEKPermission
+    /// - Parameters:
+    ///   - onset: Start date of the exposure
+    ///   - iWasExposedState: state object obtained by calling requestTEKPermission
+    ///   - authentication: Authentication method
+    ///   - callback: callback
+    @available(iOS 12.5, *)
+    public static func sendTEKs(onset: Date,
+                  iWasExposedState: IWasExposedState,
+                  authentication: ExposeeAuthMethod,
+                  callback: @escaping (Result<IWasExposedResult, DP3TTracingError>) -> Void) {
+        instancePrecondition()
+        instance.sendTEKs(onset: onset, iWasExposedState: iWasExposedState, authentication: authentication, callback: callback)
+    }
     
     /// tell the SDK that the user was exposed
+    /// This is a convenience method that for not fake requests internally first calls requestTEKPermission and then sendTEKs
+    /// This will stop tracing
     /// - Parameters:
     ///   - onset: Start date of the exposure
     ///   - authentication: Authentication method

--- a/Sources/DP3TSDK/DP3TTracingState.swift
+++ b/Sources/DP3TSDK/DP3TTracingState.swift
@@ -104,3 +104,12 @@ public enum SyncResult: Equatable {
         }
     }
 }
+
+public struct IWasExposedState {
+    internal let keys: [CodableDiagnosisKey]
+    internal let isFake: Bool
+
+    public static var fake: Self {
+        return .init(keys: [], isFake: true)
+    }
+}

--- a/Tests/DP3TSDKTests/DP3TSDKTests.swift
+++ b/Tests/DP3TSDKTests/DP3TSDKTests.swift
@@ -102,7 +102,7 @@ class DP3TSDKTests: XCTestCase {
             .init(keyData: Data(count: 16), rollingPeriod: 144, rollingStartNumber: DayDate(date: oldestDate).period, transmissionRiskLevel: 0, fake: 0),
             .init(keyData: Data(count: 16), rollingPeriod: 144, rollingStartNumber: DayDate(date: oldestDate.addingTimeInterval(.day * 2)).period, transmissionRiskLevel: 0, fake: 0),
         ]
-        sdk.iWasExposed(onset: .init(timeIntervalSinceNow: -.day), authentication: .none) { (result) in
+        sdk.iWasExposed(onset: .distantPast, authentication: .none) { (result) in
             if case let Result.success(wrapper) = result {
                 XCTAssertEqual(wrapper.oldestKeyDate, DayDate(date: oldestDate).dayMin)
             } else {


### PR DESCRIPTION
- this allows for short-lived authentication tokens